### PR TITLE
kysely-wasqlite-worker: Don't initialize the result array with the column length

### DIFF
--- a/packages/dialect-wasqlite-worker/src/worker/utils.ts
+++ b/packages/dialect-wasqlite-worker/src/worker/utils.ts
@@ -59,8 +59,7 @@ async function queryData(
   }
 
   const mapRow = createRowMapper(core.sqlite, stmt)
-  // eslint-disable-next-line unicorn/no-new-array
-  const result = new Array(size)
+  const result = []
   let idx = 0
   while (await core.sqlite.step(stmt) === SQLITE_ROW) {
     result[idx++] = mapRow(core.sqlite.row(stmt))


### PR DESCRIPTION
The result is currently being initialized as a `new Array` with a length equal to the number of _columns_ returned by the query:

https://github.com/subframe7536/kysely-sqlite-tools/blob/f1a9bf445c5b65794dd820680bb1bf961af13f11/packages/dialect-wasqlite-worker/src/worker/utils.ts#L63

I think that line can just be `const result = []`.