### PR TITLE
chore: update peer dependencies to kysely@0.28

### DIFF
--- a/packages/dialect-bun-worker/package.json
+++ b/packages/dialect-bun-worker/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "bun-types": ">=1.1.14",
-    "kysely": ">=0.26"
+    "kysely": ">=0.28"
   },
   "dependencies": {
     "kysely-generic-sqlite": "workspace:*"

--- a/packages/dialect-generic-sqlite/package.json
+++ b/packages/dialect-generic-sqlite/package.json
@@ -67,7 +67,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "kysely": ">=0.26"
+    "kysely": ">=0.28"
   },
   "devDependencies": {
     "kysely": "catalog:"

--- a/packages/dialect-sqlite-worker/package.json
+++ b/packages/dialect-sqlite-worker/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "better-sqlite3": "*",
-    "kysely": ">=0.26"
+    "kysely": ">=0.28"
   },
   "dependencies": {
     "kysely-generic-sqlite": "workspace:*"

--- a/packages/dialect-tauri/package.json
+++ b/packages/dialect-tauri/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@tauri-apps/plugin-sql": "^2.0.0",
-    "kysely": ">=0.26"
+    "kysely": ">=0.28"
   },
   "dependencies": {
     "kysely-generic-sqlite": "workspace:*"

--- a/packages/dialect-wasm/package.json
+++ b/packages/dialect-wasm/package.json
@@ -39,7 +39,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "kysely": ">=0.26"
+    "kysely": ">=0.28"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dialect-wasqlite-worker/package.json
+++ b/packages/dialect-wasqlite-worker/package.json
@@ -56,7 +56,7 @@
   },
   "peerDependencies": {
     "@subframe7536/sqlite-wasm": ">=0.5.0",
-    "kysely": ">=0.26"
+    "kysely": ">=0.28"
   },
   "dependencies": {
     "kysely-generic-sqlite": "workspace:*",


### PR DESCRIPTION
`kysely` only started exporting `createQueryId` in `0.28` which is now used in `kysely-generic-sqlite`