### PR TITLE
fix(wasqlite-worker): finalize query statements

### DIFF
--- a/packages/dialect-wasqlite-worker/src/worker/utils.ts
+++ b/packages/dialect-wasqlite-worker/src/worker/utils.ts
@@ -39,32 +39,36 @@ async function queryData(
   sql: string,
   parameters?: readonly any[],
 ): Promise<QueryResult<any>> {
-  const stmt = (await core
+  const iterator = core
     .sqlite
     .statements(core.pointer, sql)[Symbol.asyncIterator]()
-    .next()).value
+  const { value: stmt } = await iterator.next()
 
-  if (parameters?.length) {
-    core.sqlite.bind_collection(stmt, parameters)
-  }
-
-  const size = core.sqlite.column_count(stmt)
-  if (size === 0) {
-    await core.sqlite.step(stmt)
-    return {
-      rows: [],
-      insertId: parseBigInt(lastInsertRowIdCore(core)),
-      numAffectedRows: parseBigInt(changesCore(core)),
+  try {
+    if (parameters?.length) {
+      core.sqlite.bind_collection(stmt, parameters)
     }
-  }
 
-  const mapRow = createRowMapper(core.sqlite, stmt)
-  const result = []
-  let idx = 0
-  while (await core.sqlite.step(stmt) === SQLITE_ROW) {
-    result[idx++] = mapRow(core.sqlite.row(stmt))
+    const size = core.sqlite.column_count(stmt)
+    if (size === 0) {
+      await core.sqlite.step(stmt)
+      return {
+        rows: [],
+        insertId: parseBigInt(lastInsertRowIdCore(core)),
+        numAffectedRows: parseBigInt(changesCore(core)),
+      }
+    }
+
+    const mapRow = createRowMapper(core.sqlite, stmt)
+    const result = []
+    let idx = 0
+    while (await core.sqlite.step(stmt) === SQLITE_ROW) {
+      result[idx++] = mapRow(core.sqlite.row(stmt))
+    }
+    return { rows: result }
+  } finally {
+    await iterator.return?.()
   }
-  return { rows: result }
 }
 
 async function* iterateDate(


### PR DESCRIPTION
### Motivation
- Ensure the async statement iterator used in the wa-sqlite worker is always finalized so prepared-statement resources are released and query paths cannot leak or hang (fixes issue #25). 

### Description
- Replace the inline `.next()` extraction with a captured iterator and use `const { value: stmt } = await iterator.next()` to keep a reference to the iterator. 
- Run existing query logic (parameter binding, write-result handling, and row mapping) inside a `try` block and call `await iterator.return?.()` from `finally` to always close the iterator. 
- Change is limited to `packages/dialect-wasqlite-worker/src/worker/utils.ts` and preserves original result shapes and behavior for write and select statements. 

### Testing
- Ran `pnpm install` which completed successfully. 
- Built the generic worker package with `pnpm -r -F ./packages/dialect-generic-sqlite build` which succeeded. 
- Built the wasqlite worker package with `pnpm -r -F ./packages/dialect-wasqlite-worker build` which succeeded including DTS generation. 
- `pnpm exec eslint packages/dialect-wasqlite-worker/src/worker/utils.ts` failed due to a Node.js / `synckit` internal assertion during ESLint module loading and not due to this code change. 
- `pnpm run typecheck` reported unrelated workspace type resolution errors for other packages and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f1299e7288330a79698333d152964)