### PR TITLE
Expand SQLite dialect capability tests and fix worker stream/parameter issues

### DIFF
--- a/packages/dialect-bun-worker/test/index.test.ts
+++ b/packages/dialect-bun-worker/test/index.test.ts
@@ -4,7 +4,19 @@ import { testCase } from '../../test-utils'
 import { BunWorkerDialect } from '../src'
 
 describe('bun worker dialect test', () => {
-  it('bun:sqlite worker', async () => {
-    await testCase(new BunWorkerDialect() as never, expect)
+  it('bun:sqlite worker with non-cached statements', async () => {
+    await testCase(new BunWorkerDialect() as never, expect, {
+      insertId: true,
+      numAffectedRows: true,
+      stream: true,
+    })
+  })
+
+  it('bun:sqlite worker with cached statements', async () => {
+    await testCase(new BunWorkerDialect({ cacheStatment: true }) as never, expect, {
+      insertId: true,
+      numAffectedRows: true,
+      stream: true,
+    })
   })
 })

--- a/packages/dialect-generic-sqlite/src/worker/utils.ts
+++ b/packages/dialect-generic-sqlite/src/worker/utils.ts
@@ -15,7 +15,7 @@ export function createGenericOnMessageCallback<T extends Record<string, unknown>
   message?: MessageHandleFn<DB>,
 ): (data: MainToWorkerMsg<T>) => Promise<void> {
   let db: IGenericSqlite<DB>
-  return async ([type, data1, data2, data3]) => {
+  return async ([type, data1, data2, data3, data4]) => {
     const ret: WorkerToMainMsg = [type, null, null]
     try {
       switch (type) {
@@ -35,7 +35,7 @@ export function createGenericOnMessageCallback<T extends Record<string, unknown>
           if (!db.iterator) {
             throw new Error('streamQuery() is not supported.')
           }
-          const it = db.iterator(data1, data2, data3)
+          const it = db.iterator(data1, data2, data3, data4)
           for await (const row of it) {
             post([type, row as any, null] satisfies WorkerToMainMsg)
           }

--- a/packages/dialect-generic-sqlite/test/index.test.ts
+++ b/packages/dialect-generic-sqlite/test/index.test.ts
@@ -1,34 +1,79 @@
 import Database from 'better-sqlite3'
+import type { Generated } from 'kysely'
+import { Kysely } from 'kysely'
 import { describe, expect, it } from 'vitest'
 
 import { testCase } from '../../test-utils'
 import { buildQueryFn, GenericSqliteDialect, parseBigInt } from '../src'
 
+interface IsolationDB {
+  isolation: {
+    id: Generated<number>
+    name: string
+  }
+}
+
+function createDialect(db = new Database(':memory:')): GenericSqliteDialect {
+  return new GenericSqliteDialect(() => ({
+    db,
+    query: buildQueryFn({
+      all: (sql, parameters) => {
+        const stmt = db.prepare(sql)
+        if (stmt.reader) {
+          return stmt.all(parameters ?? [])
+        }
+        stmt.run(...(parameters ?? []))
+        return []
+      },
+      run: (sql, parameters) => {
+        const { changes, lastInsertRowid } = db.prepare(sql).run(...(parameters ?? []))
+        return {
+          numAffectedRows: parseBigInt(changes),
+          insertId: parseBigInt(lastInsertRowid),
+        }
+      },
+    }),
+    close: () => db.close(),
+  }))
+}
+
 describe('generic sqlite dialect test', () => {
   it('better-sqlite3 executor', async () => {
-    const db = new Database(':memory:')
-    const dialect = new GenericSqliteDialect(() => ({
-      db,
-      query: buildQueryFn({
-        all: (sql, parameters) => {
-          const stmt = db.prepare(sql)
-          if (stmt.reader) {
-            return stmt.all(parameters ?? [])
-          }
-          stmt.run(parameters ?? [])
-          return []
-        },
-        run: (sql, parameters) => {
-          const { changes, lastInsertRowid } = db.prepare(sql).run(parameters ?? [])
-          return {
-            numAffectedRows: parseBigInt(changes),
-            insertId: parseBigInt(lastInsertRowid),
-          }
-        },
-      }),
-      close: () => db.close(),
-    }))
+    await testCase(createDialect(), expect, { insertId: true, stream: false })
+  })
 
-    await testCase(dialect, expect, false)
+  it('isolates requests across independent executors', async () => {
+    const first = new Kysely<IsolationDB>({ dialect: createDialect() })
+    const second = new Kysely<IsolationDB>({ dialect: createDialect() })
+
+    try {
+      await Promise.all([
+        first.schema
+          .createTable('isolation')
+          .addColumn('id', 'integer', (builder) => builder.autoIncrement().primaryKey())
+          .addColumn('name', 'text')
+          .execute(),
+        second.schema
+          .createTable('isolation')
+          .addColumn('id', 'integer', (builder) => builder.autoIncrement().primaryKey())
+          .addColumn('name', 'text')
+          .execute(),
+      ])
+
+      await Promise.all([
+        first.insertInto('isolation').values({ name: 'first' }).execute(),
+        second.insertInto('isolation').values({ name: 'second' }).execute(),
+      ])
+
+      const [firstRows, secondRows] = await Promise.all([
+        first.selectFrom('isolation').select('name').execute(),
+        second.selectFrom('isolation').select('name').execute(),
+      ])
+
+      expect(firstRows).toStrictEqual([{ name: 'first' }])
+      expect(secondRows).toStrictEqual([{ name: 'second' }])
+    } finally {
+      await Promise.all([first.destroy(), second.destroy()])
+    }
   })
 })

--- a/packages/dialect-sqlite-worker/test/index.test.ts
+++ b/packages/dialect-sqlite-worker/test/index.test.ts
@@ -9,6 +9,10 @@ describe('sqlite worker dialect test', () => {
       source: ':memory:',
       workerPath: new URL('../dist/worker.mjs', import.meta.url) as never,
     })
-    await testCase(dialect as never, expect, true)
+    await testCase(dialect as never, expect, {
+      insertId: true,
+      numAffectedRows: true,
+      stream: true,
+    })
   })
 })

--- a/packages/dialect-tauri/test/index.test.ts
+++ b/packages/dialect-tauri/test/index.test.ts
@@ -38,6 +38,6 @@ describe('tauri sqlite dialect test', () => {
       database: new TauriSqliteMock() as never,
     })
 
-    await testCase(dialect, expect, false)
+    await testCase(dialect, expect, { insertId: true, stream: false })
   })
 })

--- a/packages/dialect-wasm/src/node-wasm-dialect/index.ts
+++ b/packages/dialect-wasm/src/node-wasm-dialect/index.ts
@@ -23,8 +23,8 @@ export class NodeWasmDialect extends GenericSqliteDialect {
           all: (sql, parameters) => {
             return db.all(sql, parameters as any)
           },
-          run: (sql) => {
-            const { changes, lastInsertRowid } = db.run(sql)
+          run: (sql, parameters) => {
+            const { changes, lastInsertRowid } = db.run(sql, parameters as any)
             return {
               insertId: BigInt(lastInsertRowid),
               numAffectedRows: BigInt(changes),

--- a/packages/dialect-wasm/test/index.test.ts
+++ b/packages/dialect-wasm/test/index.test.ts
@@ -13,13 +13,13 @@ describe('dialect test', () => {
         return new SQL.Database()
       },
     })
-    await testCase(dialect, expect, false)
+    await testCase(dialect, expect, { insertId: true, stream: false })
   })
 
   it('node-wasm', async () => {
     const dialect = new NodeWasmDialect({
       database: new Database(':memory:'),
     })
-    await testCase(dialect, expect)
+    await testCase(dialect, expect, { insertId: true, stream: true })
   })
 })

--- a/packages/dialect-wasqlite-worker/test/index.test.ts
+++ b/packages/dialect-wasqlite-worker/test/index.test.ts
@@ -6,6 +6,7 @@ import { testCase } from '../../test-utils'
 import { WaSqliteWorkerDialect } from '../src'
 
 class WebWorkerMock {
+  readonly messages: unknown[] = []
   onmessage: ((event: MessageEvent) => void) | null = null
   readonly #worker: NodeWorker
 
@@ -15,6 +16,7 @@ class WebWorkerMock {
   }
 
   postMessage(data: unknown): void {
+    this.messages.push(data)
     this.#worker.postMessage(data)
   }
 
@@ -33,6 +35,25 @@ describe('wasqlite worker dialect test', () => {
       worker: new WebWorkerMock(new URL('./worker.mock.ts', import.meta.url)) as never,
     })
 
-    await testCase(dialect, expect, true)
+    await testCase(dialect, expect, { stream: true })
+  })
+
+  it('propagates chunkSize to the worker stream request', async () => {
+    const worker = new WebWorkerMock(new URL('./worker.mock.ts', import.meta.url))
+    const dialect = new WaSqliteWorkerDialect({
+      fileName: ':memory:',
+      preferOPFS: false,
+      worker: worker as never,
+    })
+
+    await testCase(dialect, expect, { stream: true })
+
+    expect(worker.messages).toContainEqual([
+      '3',
+      true,
+      'select "name" from "test" where "name" like ? order by "age"',
+      ['stream%'],
+      2,
+    ])
   })
 })

--- a/packages/test-utils.ts
+++ b/packages/test-utils.ts
@@ -8,10 +8,64 @@ interface TestTable {
   id: Generated<number>
   name: string
   age: number
-  int8: Uint8Array
+  int8: Uint8Array | null
 }
-export async function testCase(dialect: Dialect, expect: any, supportStream = true): Promise<void> {
+
+export interface TestCaseCapabilities {
+  stream?: boolean
+  streamAbortSignal?: boolean
+  insertId?: boolean
+  numAffectedRows?: boolean
+}
+
+const defaultCapabilities: Required<TestCaseCapabilities> = {
+  stream: true,
+  streamAbortSignal: false,
+  insertId: false,
+  numAffectedRows: false,
+}
+
+export async function testCase(
+  dialect: Dialect,
+  expect: any,
+  capabilities: TestCaseCapabilities | boolean = {},
+): Promise<void> {
+  const support = normalizeCapabilities(capabilities)
   const db = new Kysely<DB>({ dialect })
+
+  try {
+    await createSchema(db)
+    await assertInsert(db, expect, dialect, support)
+    await assertParameterizedSelect(db, expect)
+    await assertParameterizedUpdate(db, expect)
+    await assertParameterizedDelete(db, expect)
+    await assertRawCompiledQuery(db, expect, support)
+    await assertTransaction(db, expect)
+    await assertSavepoint(db, expect)
+
+    if (support.stream) {
+      await assertMultiRowStream(db, expect)
+      await assertEmptyStream(db, expect)
+    }
+
+    if (support.streamAbortSignal) {
+      await assertAbortSignalStream(dialect, expect)
+    }
+  } finally {
+    await db.destroy()
+  }
+}
+
+function normalizeCapabilities(
+  capabilities: TestCaseCapabilities | boolean,
+): Required<TestCaseCapabilities> {
+  if (typeof capabilities === 'boolean') {
+    return { ...defaultCapabilities, stream: capabilities }
+  }
+  return { ...defaultCapabilities, ...capabilities }
+}
+
+async function createSchema(db: Kysely<DB>): Promise<void> {
   await db.schema
     .createTable('test')
     .addColumn('id', 'integer', (builder) => builder.autoIncrement().primaryKey())
@@ -19,46 +73,196 @@ export async function testCase(dialect: Dialect, expect: any, supportStream = tr
     .addColumn('age', 'integer')
     .addColumn('int8', 'blob')
     .execute()
-  await db
+}
+
+async function assertInsert(
+  db: Kysely<DB>,
+  expect: any,
+  dialect: Dialect,
+  support: Required<TestCaseCapabilities>,
+): Promise<void> {
+  const result = await db
     .insertInto('test')
     .values({
       age: 18,
       name: `test ${dialect.toString()}`,
       int8: new Uint8Array([1, 2, 3]),
     })
-    .execute()
+    .executeTakeFirstOrThrow()
+
+  if (support.insertId) {
+    expect(result.insertId).toStrictEqual(1n)
+  }
+}
+
+async function assertParameterizedSelect(db: Kysely<DB>, expect: any): Promise<void> {
   const { age, name, int8 } = await db
     .selectFrom('test')
     .selectAll()
+    .where('age', '=', 18)
+    .where('name', 'like', 'test%')
     .limit(1)
     .executeTakeFirstOrThrow()
-  expect(age).toStrictEqual(18)
-  expect(name).toStrictEqual(`test ${dialect.toString()}`)
-  expect(Array.from(int8)).toStrictEqual([1, 2, 3])
-  if (supportStream) {
-    const rows = db.selectFrom('test').selectAll().stream()
-    let count = 0
-    for await (const row of rows) {
-      count++
-      expect(row.age).toStrictEqual(18)
-      expect(row.name).toStrictEqual(`test ${dialect.toString()}`)
-      expect(Array.from(row.int8)).toStrictEqual([1, 2, 3])
-    }
-    expect(count).toStrictEqual(1)
-  }
 
-  const result = await db.executeQuery(
+  expect(age).toStrictEqual(18)
+  expect(name.startsWith('test ')).toStrictEqual(true)
+  expect(Array.from(int8!)).toStrictEqual([1, 2, 3])
+}
+
+async function assertParameterizedUpdate(db: Kysely<DB>, expect: any): Promise<void> {
+  await db
+    .updateTable('test')
+    .set({ age: 19 })
+    .where('age', '=', 18)
+    .where('name', 'like', 'test%')
+    .executeTakeFirstOrThrow()
+
+  const row = await db
+    .selectFrom('test')
+    .select('age')
+    .where('id', '=', 1)
+    .executeTakeFirstOrThrow()
+  expect(row.age).toStrictEqual(19)
+}
+
+async function assertParameterizedDelete(db: Kysely<DB>, expect: any): Promise<void> {
+  await db.insertInto('test').values({ age: 21, name: 'delete me', int8: null }).execute()
+  await db
+    .deleteFrom('test')
+    .where('age', '=', 21)
+    .where('name', '=', 'delete me')
+    .executeTakeFirstOrThrow()
+
+  const row = await db
+    .selectFrom('test')
+    .select('id')
+    .where('name', '=', 'delete me')
+    .executeTakeFirst()
+  expect(row).toBeUndefined()
+}
+
+async function assertRawCompiledQuery(
+  db: Kysely<DB>,
+  expect: any,
+  support: Required<TestCaseCapabilities>,
+): Promise<void> {
+  const insert = await db.executeQuery(
     CompiledQuery.raw('insert into test("age", "name") values (?, ?) returning *', [
       20,
       'test name',
     ]),
   )
-  expect(result.rows[0]).toStrictEqual({
-    age: 20,
-    id: 2,
-    int8: null,
-    name: 'test name',
+  expect(insert.rows[0]).toStrictEqual({ age: 20, id: 3, int8: null, name: 'test name' })
+
+  const update = await db.executeQuery(
+    CompiledQuery.raw('update test set age = ? where id = ?', [22, 1]),
+  )
+  if (support.numAffectedRows) {
+    expect((update as any).numAffectedRows).toStrictEqual(1n)
+  }
+}
+
+async function assertTransaction(db: Kysely<DB>, expect: any): Promise<void> {
+  await db.transaction().execute(async (trx) => {
+    await trx.insertInto('test').values({ age: 30, name: 'transaction', int8: null }).execute()
   })
 
-  await db.destroy()
+  const row = await db
+    .selectFrom('test')
+    .select('age')
+    .where('name', '=', 'transaction')
+    .executeTakeFirstOrThrow()
+  expect(row.age).toStrictEqual(30)
+}
+
+async function assertSavepoint(db: Kysely<DB>, expect: any): Promise<void> {
+  const trx = await db.startTransaction().execute()
+  try {
+    await trx
+      .insertInto('test')
+      .values({ age: 31, name: 'savepoint committed', int8: null })
+      .execute()
+
+    const savepoint = await trx.savepoint('test_savepoint').execute()
+    await savepoint
+      .insertInto('test')
+      .values({ age: 32, name: 'savepoint rolled back', int8: null })
+      .execute()
+    await savepoint.rollbackToSavepoint('test_savepoint').execute()
+    await savepoint.commit().execute()
+  } catch (error) {
+    await trx.rollback().execute()
+    throw error
+  }
+
+  const committed = await db
+    .selectFrom('test')
+    .select('id')
+    .where('name', '=', 'savepoint committed')
+    .executeTakeFirst()
+  const rolledBack = await db
+    .selectFrom('test')
+    .select('id')
+    .where('name', '=', 'savepoint rolled back')
+    .executeTakeFirst()
+
+  expect(committed).toBeDefined()
+  expect(rolledBack).toBeUndefined()
+}
+
+async function assertMultiRowStream(db: Kysely<DB>, expect: any): Promise<void> {
+  await db
+    .insertInto('test')
+    .values([
+      { age: 40, name: 'stream 1', int8: null },
+      { age: 41, name: 'stream 2', int8: null },
+      { age: 42, name: 'stream 3', int8: null },
+    ])
+    .execute()
+
+  const rows: string[] = []
+  for await (const row of db
+    .selectFrom('test')
+    .select(['name'])
+    .where('name', 'like', 'stream%')
+    .orderBy('age')
+    .stream(2)) {
+    rows.push(row.name)
+  }
+
+  expect(rows).toStrictEqual(['stream 1', 'stream 2', 'stream 3'])
+}
+
+async function assertEmptyStream(db: Kysely<DB>, expect: any): Promise<void> {
+  let count = 0
+  for await (const _ of db
+    .selectFrom('test')
+    .selectAll()
+    .where('name', '=', 'missing stream row')
+    .stream()) {
+    count++
+  }
+  expect(count).toStrictEqual(0)
+}
+
+async function assertAbortSignalStream(dialect: Dialect, expect: any): Promise<void> {
+  const driver = dialect.createDriver()
+  await driver.init()
+  const connection = await driver.acquireConnection()
+  const controller = new AbortController()
+  controller.abort()
+
+  try {
+    const stream = (connection.streamQuery as any)(CompiledQuery.raw('select 1 as value'), 1, {
+      signal: controller.signal,
+    })
+    let count = 0
+    for await (const _ of stream) {
+      count++
+    }
+    expect(count).toStrictEqual(0)
+  } finally {
+    await driver.releaseConnection(connection)
+    await driver.destroy()
+  }
 }


### PR DESCRIPTION
### Motivation
- 提供统一的、 capability 驱动的测试入口以覆盖参数化查询、原生编译查询、事务/保存点与流行为，减少各方重复并显式记录不支持的能力。
- 为各方方言补充后端特定断言（`insertId` / `numAffectedRows`）以及 worker-stream 行为测试，确保跨 executor 的请求隔离与 `chunkSize` 正确传播。

### Description
- 将共享测试抽象化到 `packages/test-utils.ts`，新增 capability flag 支持 (`stream`, `streamAbortSignal`, `insertId`, `numAffectedRows`) 并实现：参数化 select/update/delete、raw compiled query、事务与 savepoint、多行流、空流与 abort-signal 流测试。
- 在各方言测试中按能力显式传入 capability flags，包括 Bun 两个用例（cached / non-cached statements）、generic sqlite 的独立 executor 隔离测试、wasqlite worker 的 `chunkSize` 传播断言，以及 sqlite-worker / tauri / wasm 的能力开关。
- 修复并转发 worker 流请求的 `chunkSize`：`packages/dialect-generic-sqlite/src/worker/utils.ts` 将第五个参数传递给 executor iterator；并修正 node-wasm dialect 的 `run` 实现以传递绑定参数。
- 若干小改动：保证 insert/update/delete 的断言在支持时检查 `insertId`/`numAffectedRows`，并把一些测试调用改为 `executeTakeFirstOrThrow()` 等以确保行为一致。

### Testing
- 运行 `pnpm build` 成功（workspace packages 构建通过）。
- 运行 `pnpm exec vitest run`：包含新增与修改的包测试，所有测试套件通过（测试报告显示全部通过）。
- 运行 `pnpm exec oxlint`/`pnpm exec oxfmt`：格式化并静态检查已应用于受影响文件（通过/已修复格式问题）。
- 运行 `pnpm typecheck`：仍然失败，属于仓库中已存在的类型问题（`kysely` 的 `AbortableOperationOptions` 导出与 `@subframe7536/sqlite-wasm` 的导出差异），因此未在本次变更中修复。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a424eabeb588330ab1db5cbe5899b47)