### PR TITLE
Fix worker stream response buffering

### DIFF
--- a/packages/dialect-generic-sqlite/src/worker/driver.ts
+++ b/packages/dialect-generic-sqlite/src/worker/driver.ts
@@ -63,15 +63,17 @@ export class GenericSqliteWorkerDriver<
   }
 }
 
+type PendingRun = { resolve: (data: any) => void; reject: (err: any) => void }
+type StreamResult<R> = [data: QueryResult<R> | undefined, done: boolean]
+type PendingStream = {
+  queue: StreamResult<any>[]
+  wait?: PendingRun
+  error?: unknown
+}
+
 class GenericSqliteWorkerConnection implements DatabaseConnection {
-  private pendingRuns = new Map<
-    string,
-    { resolve: (data: any) => void; reject: (err: any) => void }
-  >()
-  private pendingStreams = new Map<
-    string,
-    { resolve: (data: any) => void; reject: (err: any) => void }
-  >()
+  private pendingRuns = new Map<string, PendingRun>()
+  private pendingStreams = new Map<string, PendingStream>()
 
   constructor(
     readonly worker: IGenericWorker,
@@ -103,10 +105,9 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
         return
       }
       if (err) {
-        this.pendingStreams.delete(queryId)
-        state.reject(err)
+        this.rejectStream(queryId, state, err)
       } else {
-        state.resolve([{ rows: [data] }, false])
+        this.pushStreamResult(queryId, state, [{ rows: [data] }, false])
       }
     })
 
@@ -118,11 +119,10 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
       if (!state) {
         return
       }
-      this.pendingStreams.delete(queryId)
       if (err) {
-        state.reject(err)
+        this.rejectStream(queryId, state, err)
       } else {
-        state.resolve([undefined, true])
+        this.pushStreamResult(queryId, state, [undefined, true])
       }
     })
   }
@@ -136,6 +136,9 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
       return
     }
 
+    const streamState: PendingStream = { queue: [] }
+    this.pendingStreams.set(queryId.queryId, streamState)
+
     this.worker.postMessage([
       dataEvent,
       queryId.queryId,
@@ -144,32 +147,20 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
       parameters,
       chunkSize,
     ] satisfies StreamMsg)
-    type ResolveData = [data: QueryResult<R> | undefined, done: boolean]
-    let done = false
-    let rejectFn: (reason?: any) => void
 
-    const onAbort = (): void => rejectFn(new Error('Query aborted'))
+    const onAbort = (): void => {
+      this.rejectStream(queryId.queryId, streamState, new Error('Query aborted'))
+    }
     options?.signal?.addEventListener('abort', onAbort, { once: true })
 
-    const streamState: { resolve: (data: any) => void; reject: (err: any) => void } = {
-      resolve: undefined!,
-      reject: undefined!,
-    }
-    this.pendingStreams.set(queryId.queryId, streamState)
-
     try {
-      while (!done) {
-        const [data, isDone] = await new Promise<ResolveData>((res, rej) => {
-          rejectFn = rej
-          streamState.resolve = res
-          streamState.reject = rej
-        })
+      while (true) {
+        const [data, isDone] = await this.nextStreamResult<R>(streamState)
 
         if (isDone) {
-          done = true
-        } else {
-          yield data!
+          return
         }
+        yield data!
       }
     } finally {
       options?.signal?.removeEventListener('abort', onAbort)
@@ -179,16 +170,52 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
 
   async executeQuery<R>(compiledQuery: CompiledQuery<unknown>): Promise<QueryResult<R>> {
     const { parameters, sql, query, queryId } = compiledQuery
-    this.worker.postMessage([
-      runEvent,
-      queryId.queryId,
-      SelectQueryNode.is(query),
-      sql,
-      parameters,
-    ] satisfies RunMsg)
-
     return new Promise((resolve, reject) => {
       this.pendingRuns.set(queryId.queryId, { resolve, reject })
+      this.worker.postMessage([
+        runEvent,
+        queryId.queryId,
+        SelectQueryNode.is(query),
+        sql,
+        parameters,
+      ] satisfies RunMsg)
     })
+  }
+
+  private nextStreamResult<R>(state: PendingStream): Promise<StreamResult<R>> {
+    const queued = state.queue.shift()
+    if (queued) {
+      return Promise.resolve(queued)
+    }
+    if (state.error) {
+      return Promise.reject(state.error)
+    }
+    return new Promise((resolve, reject) => {
+      state.wait = { resolve, reject }
+    })
+  }
+
+  private pushStreamResult(queryId: string, state: PendingStream, result: StreamResult<any>): void {
+    if (state.wait) {
+      const { resolve } = state.wait
+      state.wait = undefined
+      resolve(result)
+      return
+    }
+    state.queue.push(result)
+    if (result[1]) {
+      this.pendingStreams.delete(queryId)
+    }
+  }
+
+  private rejectStream(queryId: string, state: PendingStream, err: unknown): void {
+    this.pendingStreams.delete(queryId)
+    state.queue.length = 0
+    state.error = err
+    if (state.wait) {
+      const { reject } = state.wait
+      state.wait = undefined
+      reject(err)
+    }
   }
 }

--- a/packages/dialect-generic-sqlite/test/index.test.ts
+++ b/packages/dialect-generic-sqlite/test/index.test.ts
@@ -1,9 +1,11 @@
 import Database from 'better-sqlite3'
+import { CompiledQuery } from 'kysely'
 import { describe, expect, it } from 'vitest'
 
 import { testCase } from '../../test-utils'
 import { buildQueryFn, GenericSqliteDialect, parseBigInt } from '../src'
-import { createGenericOnMessageCallback } from '../src/worker'
+import { createGenericOnMessageCallback, GenericSqliteWorkerDialect } from '../src/worker'
+import type { IGenericEventEmitter } from '../src/worker'
 import { initEvent, dataEvent, runEvent } from '../src/worker/types'
 
 describe('generic sqlite dialect test', () => {
@@ -65,4 +67,81 @@ describe('generic sqlite dialect test', () => {
       ['4', 'stream-a', null, null],
     ])
   })
+  it('buffers synchronous worker stream rows without dropping data', async () => {
+    const mitt = createTestMitt()
+    const messages: unknown[] = []
+    const onMessage = createGenericOnMessageCallback(
+      async () => ({
+        db: {},
+        close: () => {},
+        query: () => ({ rows: [] }),
+        *iterator() {
+          yield { id: 1 }
+          yield { id: 2 }
+          yield { id: 3 }
+        },
+      }),
+      (message) => {
+        messages.push(message)
+        const [type, ...args] = message as [string, ...unknown[]]
+        mitt.emit(type, ...args)
+      },
+    )
+
+    const dialect = new GenericSqliteWorkerDialect(() => ({
+      mitt,
+      worker: {
+        postMessage: (message) => void onMessage(message as never),
+        terminate: () => {},
+      },
+      handle: () => {},
+    }))
+    const driver = dialect.createDriver()
+    await driver.init()
+
+    const connection = await driver.acquireConnection()
+    const query = CompiledQuery.raw('select 1')
+    const rows: unknown[] = []
+    for await (const result of connection.streamQuery(query, 1)) {
+      rows.push(...result.rows)
+    }
+    await driver.releaseConnection(connection)
+    await driver.destroy()
+
+    expect(rows).toStrictEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
+    expect(messages).toHaveLength(6)
+  })
 })
+
+function createTestMitt(): IGenericEventEmitter {
+  const listeners = new Map<string, Set<(...value: any[]) => void>>()
+
+  return {
+    emit: (eventName: string, ...args: any[]) => {
+      for (const listener of listeners.get(eventName) ?? []) {
+        listener(...args)
+      }
+    },
+    on: (eventName: string, callback: (...value: any[]) => void) => {
+      const eventListeners = listeners.get(eventName) ?? new Set()
+      eventListeners.add(callback)
+      listeners.set(eventName, eventListeners)
+    },
+    once: (eventName: string, callback: (...value: any[]) => void) => {
+      const onceCallback = (...value: any[]): void => {
+        listeners.get(eventName)?.delete(onceCallback)
+        callback(...value)
+      }
+      const eventListeners = listeners.get(eventName) ?? new Set()
+      eventListeners.add(onceCallback)
+      listeners.set(eventName, eventListeners)
+    },
+    off: (eventName?: string): void => {
+      if (eventName) {
+        listeners.delete(eventName)
+      } else {
+        listeners.clear()
+      }
+    },
+  }
+}


### PR DESCRIPTION
### Motivation

- Prevent synchronous or bursty worker stream messages from being lost when the consumer hasn't awaited the next row yet. 
- Avoid races where a worker replies immediately to a `run` message before the pending handler is registered.

### Description

- Introduced a queued pending-stream state with `PendingStream`, `nextStreamResult`, `pushStreamResult`, and `rejectStream` helpers to buffer stream rows until the consumer consumes them and to surface stream errors consistently in `packages/dialect-generic-sqlite/src/worker/driver.ts`.
- Register pending run handlers before posting the `run` `postMessage` to eliminate fast-response races in `executeQuery`.
- Improved abort handling for streaming by rejecting the pending stream on abort and cleaning up listeners.
- Added a regression test `buffers synchronous worker stream rows without dropping data` and a small `createTestMitt` event-emitter helper to `packages/dialect-generic-sqlite/test/index.test.ts` to cover synchronous/bursty streams.

### Testing

- Ran `pnpm typecheck` which completed successfully. 
- Ran `pnpm lint` and `pnpm format` which completed successfully. 
- Ran test suite with `pnpm test -- --runInBand` and all tests passed (`Test Files 5 passed`, `Tests 8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a430a1dcc7c8330bd5b6db0a4e613a5)