### PR TITLE
Fix wasm SQLite streaming statement lifetime

### DIFF
--- a/packages/dialect-wasm/src/dialects/official-wasm.ts
+++ b/packages/dialect-wasm/src/dialects/official-wasm.ts
@@ -76,7 +76,7 @@ export class OfficialWasmDialect extends GenericSqliteDialect {
           if (!isSelect) {
             throw new Error('Only support select query')
           }
-          return runWithStatement(db, sql, parameters, iterator)
+          return iterateWithStatement(db, sql, parameters)
         },
       }
     }, config.onCreateConnection)
@@ -103,10 +103,22 @@ function runWithStatement<T>(
 function* iterator(
   statement: import('@sqlite.org/sqlite-wasm').PreparedStatement,
 ): IterableIterator<Record<string, import('@sqlite.org/sqlite-wasm').SqlValue>> {
+  while (statement.step()) {
+    yield statement.get({})
+  }
+}
+
+function* iterateWithStatement(
+  db: import('@sqlite.org/sqlite-wasm').Database,
+  sql: string,
+  parameters: any[] | readonly any[],
+): IterableIterator<Record<string, import('@sqlite.org/sqlite-wasm').SqlValue>> {
+  const statement = db.prepare(sql)
   try {
-    while (statement.step()) {
-      yield statement.get({})
+    if (parameters.length) {
+      statement.bind(parameters as import('@sqlite.org/sqlite-wasm').BindingSpec)
     }
+    yield* iterator(statement)
   } finally {
     statement.finalize()
   }

--- a/packages/dialect-wasm/src/dialects/sqljs.ts
+++ b/packages/dialect-wasm/src/dialects/sqljs.ts
@@ -45,36 +45,31 @@ export class SqlJsDialect extends GenericSqliteDialect {
           if (!isSelect) {
             throw new Error('Only support select query')
           }
-          return runWithStatement(db, sql, parameters, iterator)
+          return iterateWithStatement(db, sql, parameters)
         },
       }
     }, config.onCreateConnection)
   }
 }
 
-function runWithStatement<T>(
+function* iterator<T>(stmt: import('sql.js').Statement): IterableIterator<T> {
+  while (stmt.step()) {
+    yield stmt.getAsObject() as unknown as T
+  }
+}
+
+function* iterateWithStatement<T>(
   db: import('sql.js').Database,
   sql: string,
   parameters: any[] | readonly any[],
-  callback: (stmt: import('sql.js').Statement) => T,
-): T {
+): IterableIterator<T> {
   const statement = db.prepare(sql)
   try {
     if (parameters.length) {
       statement.bind(parameters as any[])
     }
-    return callback(statement)
+    yield* iterator(statement)
   } finally {
     statement.free()
-  }
-}
-
-function* iterator<T>(stmt: import('sql.js').Statement): IterableIterator<T> {
-  try {
-    while (stmt.step()) {
-      yield stmt.getAsObject() as unknown as T
-    }
-  } finally {
-    stmt.free()
   }
 }

--- a/packages/dialect-wasm/test/index.test.ts
+++ b/packages/dialect-wasm/test/index.test.ts
@@ -13,7 +13,7 @@ describe('dialect test', () => {
         return new SQL.Database()
       },
     })
-    await testCase(dialect, expect, false)
+    await testCase(dialect, expect)
   })
 
   it('node-wasm', async () => {


### PR DESCRIPTION
### Motivation
- Prevent prepared statements from being freed/finalized while their stream iterators are still reading, which caused dropped rows or iterator lifetime issues for wasm-backed dialects.
- Enable the shared streaming test for `sql.js` so sql.js gets the same streaming coverage as other wasm dialects.

### Description
- Replace inline iterator use with `iterateWithStatement` helper that prepares the statement, binds parameters, yields rows via a dedicated `iterator` generator, and only frees/finalizes the statement after iteration completes in `sqljs` and `official-wasm` dialects.
- Stop calling the transient `runWithStatement` for streaming paths and instead return an iterator that keeps the statement alive for the full stream lifetime.
- Remove the now-unused `runWithStatement` declaration from `sqljs.ts` to satisfy type checks.
- Enable the streaming test for `SqlJsDialect` by removing the `supportStream=false` override in the wasm tests.

### Testing
- Ran `pnpm test`, which executed the test suite and reported `Test Files 5 passed (5)` and `Tests 10 passed (10)`.
- Ran type checking and linting with `pnpm typecheck && pnpm lint`, which completed successfully (no TypeScript or lint errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4773b393f88330833e603580263153)