### PR TITLE
Fix worker query cancellation and wasm package metadata

### DIFF
--- a/packages/dialect-bun-worker/tsdown.config.ts
+++ b/packages/dialect-bun-worker/tsdown.config.ts
@@ -9,6 +9,6 @@ export default lib({
   unbundled: ['kysely', 'bun:sqlite'],
   overrides: {
     format: ['cjs', 'esm'],
-    outExtensions: ({ format }) => ({ js: format === 'es' ? '.mjs' : '.cjs' }),
+    fixedExtension: true,
   },
 })

--- a/packages/dialect-generic-sqlite/package.json
+++ b/packages/dialect-generic-sqlite/package.json
@@ -26,7 +26,7 @@
   ],
   "type": "module",
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
   "typesVersions": {
     "*": {
@@ -43,19 +43,19 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./worker": {
-      "import": "./dist/worker.js",
+      "import": "./dist/worker.mjs",
       "require": "./dist/worker.cjs"
     },
     "./worker-helper-node": {
-      "import": "./dist/worker-helper-node.js",
+      "import": "./dist/worker-helper-node.mjs",
       "require": "./dist/worker-helper-node.cjs"
     },
     "./worker-helper-web": {
-      "import": "./dist/worker-helper-web.js",
+      "import": "./dist/worker-helper-web.mjs",
       "require": "./dist/worker-helper-web.cjs"
     },
     "./package.json": "./package.json"

--- a/packages/dialect-generic-sqlite/src/worker/driver.ts
+++ b/packages/dialect-generic-sqlite/src/worker/driver.ts
@@ -196,7 +196,7 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
 
     return new Promise((resolve, reject) => {
       const queryKey = queryId.queryId
-      let cleanup: () => void
+      let cleanup = (): void => {}
       const onAbort = (): void => {
         cleanup()
         reject(new Error('Query aborted'))

--- a/packages/dialect-generic-sqlite/src/worker/driver.ts
+++ b/packages/dialect-generic-sqlite/src/worker/driver.ts
@@ -185,17 +185,51 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
     }
   }
 
-  async executeQuery<R>(compiledQuery: CompiledQuery<unknown>): Promise<QueryResult<R>> {
+  async executeQuery<R>(
+    compiledQuery: CompiledQuery<unknown>,
+    options?: AbortableOperationOptions,
+  ): Promise<QueryResult<R>> {
     const { parameters, sql, query, queryId } = compiledQuery
+    if (options?.signal?.aborted) {
+      throw new Error('Query aborted')
+    }
+
     return new Promise((resolve, reject) => {
-      this.pendingRuns.set(queryId.queryId, { resolve, reject })
-      this.worker.postMessage([
-        runEvent,
-        queryId.queryId,
-        SelectQueryNode.is(query),
-        sql,
-        parameters,
-      ] satisfies RunMsg)
+      const queryKey = queryId.queryId
+      let cleanup: () => void
+      const onAbort = (): void => {
+        cleanup()
+        reject(new Error('Query aborted'))
+      }
+      cleanup = (): void => {
+        this.pendingRuns.delete(queryKey)
+        options?.signal?.removeEventListener('abort', onAbort)
+      }
+      const settle =
+        <T>(callback: (value: T) => void) =>
+        (value: T): void => {
+          cleanup()
+          callback(value)
+        }
+
+      this.pendingRuns.set(queryKey, {
+        resolve: settle(resolve),
+        reject: settle(reject),
+      })
+      options?.signal?.addEventListener('abort', onAbort, { once: true })
+
+      try {
+        this.worker.postMessage([
+          runEvent,
+          queryKey,
+          SelectQueryNode.is(query),
+          sql,
+          parameters,
+        ] satisfies RunMsg)
+      } catch (error) {
+        cleanup()
+        reject(error)
+      }
     })
   }
 

--- a/packages/dialect-generic-sqlite/test/index.test.ts
+++ b/packages/dialect-generic-sqlite/test/index.test.ts
@@ -219,6 +219,43 @@ describe('generic sqlite dialect test', () => {
     await expect(driver.destroy()).resolves.toBeUndefined()
   })
 
+  it('rejects aborted worker queries and ignores late responses', async () => {
+    const mitt = createTestMitt()
+    let capturedMessage: unknown[] | undefined
+    const driver = new GenericSqliteWorkerDialect(() => ({
+      mitt,
+      worker: {
+        postMessage: (message) => {
+          const [type] = message as [string]
+          if (type === initEvent || type === closeEvent) {
+            mitt.emit(type, null, null, null)
+            return
+          }
+          capturedMessage = message as unknown[]
+        },
+        terminate: () => {},
+      },
+      handle: () => {},
+    })).createDriver()
+
+    await driver.init()
+
+    const controller = new AbortController()
+    const connection = await driver.acquireConnection()
+    const promise = connection.executeQuery(CompiledQuery.raw('select 1'), {
+      signal: controller.signal,
+    })
+
+    controller.abort()
+
+    await expect(promise).rejects.toThrow('Query aborted')
+    expect(capturedMessage?.[0]).toBe(runEvent)
+
+    mitt.emit(runEvent, capturedMessage?.[1], { rows: [{ id: 1 }] }, null)
+
+    await expect(driver.destroy()).resolves.toBeUndefined()
+  })
+
   it('buffers synchronous worker stream rows without dropping data', async () => {
     const mitt = createTestMitt()
     const messages: unknown[] = []

--- a/packages/dialect-generic-sqlite/tsdown.config.ts
+++ b/packages/dialect-generic-sqlite/tsdown.config.ts
@@ -10,5 +10,6 @@ export default lib({
   },
   overrides: {
     format: ['esm', 'cjs'],
+    fixedExtension: true,
   },
 })

--- a/packages/dialect-sqlite-worker/tsdown.config.ts
+++ b/packages/dialect-sqlite-worker/tsdown.config.ts
@@ -9,7 +9,7 @@ export default lib({
   },
   overrides: {
     format: ['cjs', 'esm'],
-    outExtensions: ({ format }) => ({ js: format === 'es' ? '.mjs' : '.cjs' }),
+    fixedExtension: true,
     plugins: [correctWorkerPathPlugin()],
   },
 })

--- a/packages/dialect-tauri/tsdown.config.ts
+++ b/packages/dialect-tauri/tsdown.config.ts
@@ -4,6 +4,6 @@ export default lib({
   unbundled: ['kysely'],
   overrides: {
     format: ['cjs', 'esm'],
-    outExtensions: ({ format }) => ({ js: format === 'es' ? '.mjs' : '.cjs' }),
+    fixedExtension: true,
   },
 })

--- a/packages/dialect-wasm/package.json
+++ b/packages/dialect-wasm/package.json
@@ -24,6 +24,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/dialect-wasm/package.json
+++ b/packages/dialect-wasm/package.json
@@ -25,13 +25,13 @@
     "dist"
   ],
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.cts",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/dialect-wasm/tsdown.config.ts
+++ b/packages/dialect-wasm/tsdown.config.ts
@@ -10,6 +10,6 @@ export default lib({
   ],
   overrides: {
     format: ['cjs', 'esm'],
-    outExtensions: ({ format }) => ({ js: format === 'es' ? '.mjs' : '.js' }),
+    fixedExtension: true,
   },
 })


### PR DESCRIPTION
### Motivation
- Worker-based query execution did not properly honor abort signals, leaving pending state and allowing late responses to affect settled callers.  
- Tests lacked coverage for aborted worker queries and late responses.  
- The wasm package emitted a Node module-type reparsing warning during builds because it was not marked as ESM.  

### Description
- Updated `GenericSqliteWorkerConnection.executeQuery` to accept `AbortableOperationOptions`, immediately throw if the signal is already aborted, register an `abort` listener, and remove pending query state and listeners on abort or settlement.  
- Wrapped pending `resolve`/`reject` handlers to perform cleanup and added a `try/catch` around `postMessage` to clean up and reject if posting fails.  
- Added a regression test `rejects aborted worker queries and ignores late responses` to `packages/dialect-generic-sqlite/test/index.test.ts` that verifies aborted queries reject and late worker replies are ignored.  
- Marked `packages/dialect-wasm/package.json` with `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dfeac06bc83308284d7feae12e9f5)