### PR TITLE
refactor(generic-sqlite): replace worker protocol with pull-based RPC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,34 @@ jobs:
           node-version: 24
           cache: 'pnpm'
 
+      - uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
 
-      - name: QA
-        run: pnpm qa
+      - name: Lint check
+        run: pnpm lint:check
+
+      - name: Format check
+        run: pnpm format:check
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Vitest tests
+        run: pnpm test
+
+      - name: Bun tests
+        run: pnpm test:bun
+
+      - name: Package smoke tests
+        run: pnpm smoke:packages
+
+      - name: Verify checks did not mutate files
+        run: git diff --exit-code
 
       - name: Update npm
         run: npm install -g npm@latest

--- a/package.json
+++ b/package.json
@@ -19,12 +19,16 @@
     "release": "pnpm install && bumpp package.json packages/dialect*/package.json",
     "play": "pnpm --dir playground dev",
     "play:build": "pnpm build && pnpm --dir playground build",
-    "test": "pnpm build && vitest run",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit && pnpm --dir playground exec tsc --noEmit",
     "format": "oxfmt",
     "lint": "oxlint",
     "qa": "pnpm build && oxlint --fix && oxfmt && tsc --noEmit && pnpm --dir playground exec tsc --noEmit",
-    "test:bun": "pnpm --filter kysely-generic-sqlite build && pnpm --filter kysely-bun-worker test"
+    "test:bun": "pnpm --filter kysely-generic-sqlite build && pnpm --filter kysely-bun-worker test",
+    "lint:check": "oxlint",
+    "format:check": "oxfmt --check",
+    "qa:check": "pnpm build && pnpm lint:check && pnpm format:check && pnpm typecheck && pnpm test && pnpm test:bun && pnpm smoke:packages && git diff --exit-code",
+    "smoke:packages": "node scripts/package-smoke.mjs"
   },
   "devDependencies": {
     "@sqlite.org/sqlite-wasm": "3.53.0-build1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "release": "pnpm install && bumpp package.json packages/dialect*/package.json",
     "play": "pnpm --dir playground dev",
     "play:build": "pnpm build && pnpm --dir playground build",
-    "test": "vitest run",
+    "test": "vitest run && pnpm run test:bun",
     "typecheck": "tsc --noEmit && pnpm --dir playground exec tsc --noEmit",
     "format": "oxfmt",
     "lint": "oxlint",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test:bun": "pnpm --filter kysely-generic-sqlite build && pnpm --filter kysely-bun-worker test",
     "lint:check": "oxlint",
     "format:check": "oxfmt --check",
-    "qa:check": "pnpm build && pnpm lint:check && pnpm format:check && pnpm typecheck && pnpm test && pnpm test:bun && pnpm smoke:packages && git diff --exit-code",
     "smoke:packages": "node scripts/package-smoke.mjs"
   },
   "devDependencies": {

--- a/packages/dialect-bun-worker/package.json
+++ b/packages/dialect-bun-worker/package.json
@@ -31,10 +31,10 @@
   "typesVersions": {
     "*": {
       "normal": [
-        "./dist/normal.d.ts"
+        "./dist/normal.d.mts"
       ],
       "worker": [
-        "./dist/worker.d.ts"
+        "./dist/worker.d.mts"
       ]
     }
   },

--- a/packages/dialect-bun-worker/src/index.ts
+++ b/packages/dialect-bun-worker/src/index.ts
@@ -1,5 +1,4 @@
 import { GenericSqliteWorkerDialect } from 'kysely-generic-sqlite/worker'
-import { createNodeMitt } from 'kysely-generic-sqlite/worker-helper-node'
 import { handleWebWorker } from 'kysely-generic-sqlite/worker-helper-web'
 
 import type { BunWorkerDialectConfig, InitData } from './type'
@@ -27,7 +26,6 @@ export class BunWorkerDialect extends GenericSqliteWorkerDialect<globalThis.Work
     super(
       () => ({
         data: { cache: cacheStatement, fileName, opt },
-        mitt: createNodeMitt(),
         handle: handleWebWorker,
         worker,
       }),

--- a/packages/dialect-bun-worker/src/worker/utils.ts
+++ b/packages/dialect-bun-worker/src/worker/utils.ts
@@ -1,7 +1,7 @@
 import Database from 'bun:sqlite'
 
 import type { Promisable } from 'kysely-generic-sqlite'
-import type { MessageHandleFn } from 'kysely-generic-sqlite/worker'
+import type { WorkerRequestHandler } from 'kysely-generic-sqlite/worker'
 import { createWebOnMessageCallback } from 'kysely-generic-sqlite/worker-helper-web'
 
 import { createSqliteExecutor } from '../executor'
@@ -35,10 +35,10 @@ export const defaultCreateDatabaseFn: CreateDatabaseFn = (fileName, opt) =>
  */
 export function createOnMessageCallback(
   create: CreateDatabaseFn,
-  message?: MessageHandleFn<Database>,
+  custom?: WorkerRequestHandler<Database>,
 ): void {
   createWebOnMessageCallback<InitData, Database>(async ({ cache, fileName, opt }) => {
     const db = await create(fileName, opt)
     return createSqliteExecutor(db, cache)
-  }, message)
+  }, custom)
 }

--- a/packages/dialect-generic-sqlite/MIGRATE_TO_V2.md
+++ b/packages/dialect-generic-sqlite/MIGRATE_TO_V2.md
@@ -1,174 +1,204 @@
-## Migrate from v1.2.x to v2.0.0
+# `kysely-generic-sqlite` v1.2.x → v2 migration guide
 
-This guide lists every breaking change between `v1.2.1` and `v2.0.0`. It is organized so an automated agent can apply each rule mechanically — every rule has a **before** (v1) and **after** (v2) code sample.
+Scope: this document only covers `kysely-generic-sqlite`. It is written for automated migration agents and humans reviewing their changes.
+
+## Agent workflow
+
+1. Read the repository's package manager files and TypeScript sources.
+2. Apply the rules below in order.
+3. Prefer public package exports over deep imports.
+4. Run the project's existing typecheck and tests.
+5. Do not change package versions unless the migration task explicitly asks for it.
+
+## Migration checklist
+
+- [ ] Set the `kysely` peer dependency range to `>=0.29`.
+- [ ] Remove code that depends on `BaseSqliteDriver` owning a connection mutex.
+- [ ] Update `BaseSqliteDriver.init` overrides/usages to accept optional `AbortableOperationOptions`.
+- [ ] Update `IGenericSqlite.query` implementations to require `parameters` and accept optional Kysely AST `node`.
+- [ ] Update `OnCreateConnection` callbacks to accept the optional `options` argument.
+- [ ] Update executor factories to accept optional `options`.
+- [ ] Update custom worker protocol handlers for `queryId`, `chunkSize`, stream cancellation, and cancellation acknowledgements.
+- [ ] Update custom `MessageHandleFn` callbacks to the v2 positional signature.
+- [ ] Update custom `streamQuery` implementations to accept `chunkSize` and `options`.
+- [ ] Replace ad-hoc lazy value resolution with `access` where useful.
+- [ ] Ensure `run(sql, parameters)` executes the real SQL when using `buildQueryFn`.
 
 ---
 
-### Rule 1 — Bump Kysely peer dependency
+## Rule 1: Kysely peer dependency is `>=0.29`
 
-`kysely` peer range changed from `>=0.26` to `>=0.29`. Update `package.json`:
+### Find
 
 ```jsonc
-// ❌ v1.2.1
 { "peerDependencies": { "kysely": ">=0.26" } }
+```
 
-// ✅ v2
+### Replace with
+
+```jsonc
 { "peerDependencies": { "kysely": ">=0.29" } }
 ```
 
-v2 relies on `SqliteAdapter.supportsMultipleConnections` (added in Kysely 0.29) to serialize access to the single SQLite connection. The `ConnectionMutex` that v1 maintained internally is removed (see Rule 2).
+### Reason
+
+v2 relies on Kysely's single-connection serialization support instead of the v1 dialect-owned mutex.
 
 ---
 
-### Rule 2 — `BaseSqliteDriver` mutex removed; `releaseConnection` is a no-op
+## Rule 2: `BaseSqliteDriver` no longer owns the connection mutex
 
-v1 had a private `ConnectionMutex` that serialized `acquireConnection` / `releaseConnection`. v2 removes it — Kysely ≥ 0.29 handles this at the adapter level.
+### Find
 
-If you extend `BaseSqliteDriver` directly:
+- Subclasses overriding `releaseConnection` only to unlock a mutex.
+- Tests or wrappers that call `driver.releaseConnection()` expecting it to unlock queued work.
+- Direct references to the old private `ConnectionMutex` behavior.
+
+### Replace with
 
 ```ts
-// ❌ v1.2.1 — override releaseConnection to unlock
 class MyDriver extends BaseSqliteDriver {
-  // acquireConnection() locks, releaseConnection() unlocks — both handle mutex
-}
-
-// ✅ v2 — releaseConnection is already implemented as a no-op; do NOT override it
-class MyDriver extends BaseSqliteDriver {
-  // acquireConnection() returns this.conn! directly
-  // releaseConnection() — inherited no-op, do not touch
+  // acquireConnection() returns the single connection.
+  // releaseConnection() is inherited as a no-op.
 }
 ```
 
-If you were calling `driver.releaseConnection()` in tests or wrapper code expecting it to unlock — remove those calls; they are harmless no-ops in v2.
+### Notes
+
+`releaseConnection()` still exists for the Kysely driver contract, but it does not unlock anything in v2.
 
 ---
 
-### Rule 3 — `BaseSqliteDriver.init` signature changed
+## Rule 3: `BaseSqliteDriver.init` accepts optional operation options
+
+### v1 shape
 
 ```ts
-// ❌ v1.2.1
 abstract class BaseSqliteDriver {
-  init: () => Promise<void> // public property, assigned in constructor
-  constructor(init: () => Promise<void>) {
-    /* ... */
-  }
-}
-
-// ✅ v2
-abstract class BaseSqliteDriver {
-  constructor(public init: (options?: AbortableOperationOptions) => Promise<void>) {}
+  init: () => Promise<void>
 }
 ```
 
-`init` is now a **constructor parameter property** (still public, still assignable). The key differences:
+### v2 shape
 
-- It now receives an optional `options?: AbortableOperationOptions` (with an `AbortSignal`).
-- The v1 constructor ran `import('kysely').then(...)` as a side effect to bind savepoint methods dynamically. v2 imports `createQueryId` statically and defines savepoint methods as concrete class members — no dynamic import side effect.
+```ts
+abstract class BaseSqliteDriver {
+  init: (options?: AbortableOperationOptions) => Promise<void>
+}
+```
 
-If you were calling `driver.init()` with no arguments — **no change needed**, the `options` parameter is optional.
+### Migration action
+
+If a subclass, test double, or wrapper types `init`, add the optional argument. Call sites that use `driver.init()` without arguments do not need to change.
 
 ---
 
-### Rule 4 — `IGenericSqlite.query` gained a 4th parameter `node`
+## Rule 4: `IGenericSqlite.query` receives required parameters and optional AST node
+
+### v1 shape
 
 ```ts
-// ❌ v1.2.1
 interface IGenericSqlite<DB> {
   query(
     isSelect: boolean,
     sql: string,
-    parameters?: any[] | readonly any[], // optional
-  ): Promisable<QueryResult<any>>
-}
-
-// ✅ v2
-interface IGenericSqlite<DB> {
-  query(
-    isSelect: boolean,
-    sql: string,
-    parameters: any[] | readonly any[], // required
-    node?: RootOperationNode, // new — Kysely query AST
+    parameters?: any[] | readonly any[],
   ): Promisable<QueryResult<any>>
 }
 ```
 
-Two changes in this signature:
-
-1. **`parameters` is now required** (was optional). If you pass `undefined`, change it to `[]`.
-2. **New 4th parameter `node`** — the Kysely query AST node, used by `isReadOrReturningQuery` to detect `RETURNING` clauses. If you hand-roll an executor, forward it; if you ignore it the dialect still works but raw-SQL `RETURNING` detection degrades.
+### v2 shape
 
 ```ts
-// ✅ v2 — hand-rolled executor
+interface IGenericSqlite<DB> {
+  query(
+    isSelect: boolean,
+    sql: string,
+    parameters: any[] | readonly any[],
+    node?: RootOperationNode,
+  ): Promisable<QueryResult<any>>
+}
+```
+
+### Migration actions
+
+1. Replace `parameters?` with required `parameters`.
+2. Pass `[]` instead of `undefined` when there are no parameters.
+3. Add the optional `node` argument.
+4. Forward `node` to `buildQueryFn` when using that helper.
+
+```ts
 const executor: IGenericSqlite = {
   query: (isSelect, sql, parameters, node) => {
-    // pass node through if using buildQueryFn
     return buildQueryFn(exec)(isSelect, sql, parameters, node)
   },
 }
 ```
 
+### Reason
+
+The AST node lets v2 detect `RETURNING` reliably without relying only on SQL text or Kysely's `isSelect` flag.
+
 ---
 
-### Rule 5 — `OnCreateConnection` callback receives a second argument
+## Rule 5: `OnCreateConnection` receives operation options
+
+### v1 shape
 
 ```ts
-// ❌ v1.2.1
 type OnCreateConnection = (connection: DatabaseConnection) => Promisable<void>
+```
 
-// ✅ v2
+### v2 shape
+
+```ts
 type OnCreateConnection = (
   connection: DatabaseConnection,
   options?: AbortableOperationOptions,
 ) => Promisable<void>
 ```
 
-All callbacks passed as the second constructor argument to `GenericSqliteDialect`, `GenericSqliteWorkerDialect`, or any `IBaseSqliteDialectConfig.onCreateConnection` now receive kysely's `AbortableOperationOptions` as the second parameter. Update callback signatures:
+### Migration action
+
+Update typed callbacks passed to `GenericSqliteDialect`, `GenericSqliteWorkerDialect`, or `IBaseSqliteDialectConfig.onCreateConnection`.
 
 ```ts
-// ❌ v1.2.1
-const dialect = new GenericSqliteDialect(factory, async (conn) => {
-  await conn.executeQuery(CompiledQuery.raw('PRAGMA journal_mode=WAL'))
-})
-
-// ✅ v2
 const dialect = new GenericSqliteDialect(factory, async (conn, options) => {
-  await conn.executeQuery(CompiledQuery.raw('PRAGMA journal_mode=WAL'))
+  await conn.executeQuery(CompiledQuery.raw('PRAGMA journal_mode=WAL'), options)
 })
 ```
 
-If you ignore the second parameter, the callback still works — just add `, _options` or `options?` to satisfy the type.
+If the callback ignores options, use `_options` or omit a type annotation and let TypeScript infer compatibility.
 
 ---
 
-### Rule 6 — Executor factory receives `options`
+## Rule 6: Executor factories receive operation options
+
+### v1 shape
 
 ```ts
-// ❌ v1.2.1
 type Factory = () => Promisable<IGenericSqlite>
+```
 
-// ✅ v2
+### v2 shape
+
+```ts
 type SqliteExecutorFactory<T> = (options?: AbortableOperationOptions) => Promisable<T>
 ```
 
-The factory passed to `GenericSqliteDialect` / `GenericSqliteWorkerDialect` constructors now receives `options`. If your factory ignores it, no change needed. If you have a type annotation, update to `SqliteExecutorFactory<IGenericSqlite>`.
+### Migration action
+
+Update explicit factory type annotations. Factory functions that ignore the parameter remain valid.
 
 ---
 
-### Rule 7 — Worker message format: `queryId` added for correlation
+## Rule 7: Worker protocol tuples include `queryId`, stream chunk size, and cancellation acknowledgement
 
-**v1.2.1 worker messages had no query ID.** `RunMsg` and `StreamMsg` were:
+This rule only applies to custom worker transports or custom `onmessage` implementations. Code that uses the provided helper functions should not need protocol tuple changes.
 
-```ts
-// ❌ v1.2.1
-type RunMsg = [type, isSelect: boolean, sql: string, parameters?: readonly unknown[]]
-type StreamMsg = [type, isSelect: boolean, sql: string, parameters?: readonly unknown[]]
-```
-
-**v2 adds `queryId`** as the second element, `chunkSize` to `StreamMsg`, and a
-stream cancellation message:
+### Main-to-worker messages
 
 ```ts
-// ✅ v2
 type RunMsg = [
   type,
   queryId: string,
@@ -176,6 +206,7 @@ type RunMsg = [
   sql: string,
   parameters: readonly unknown[],
 ]
+
 type StreamMsg = [
   type,
   queryId: string,
@@ -184,34 +215,40 @@ type StreamMsg = [
   parameters: readonly unknown[],
   chunkSize?: number,
 ]
+
 type CancelMsg = [type, queryId: string]
 ```
 
-`CancelMsg` is sent when the main thread stops consuming a worker stream before
-the worker sends `endEvent`, including aborts, early iterator close, and
-connection close. Custom worker protocol implementations must call `return()` on
-the active iterator for that `queryId` and suppress the normal end response.
-
-**Worker-side handler (`createGenericOnMessageCallback`) message destructuring changed:**
+### Worker-to-main stream messages
 
 ```ts
-// ❌ v1.2.1 — 3 data args
-return async ([type, data1, data2, data3]) => {
-  /* ... */
-}
+// One raw row per data event.
+type DataMsg<Row> = [type, queryId: string, data: Row, err: null]
 
-// ✅ v2 — 5 data args (queryId, isSelect, sql, params, chunkSize)
-return async ([type, data1, data2, data3, data4, data5]) => {
-  /* ... */
-}
+type EndMsg = [type, queryId: string, data: null, err: unknown]
+type CancelAckMsg = [type, queryId: string, data: null, err: unknown]
 ```
 
-If you wrote a custom `onmessage` handler that manually destructures the tuple, update the arity and positions. If you use `createNodeOnMessageCallback` / `createWebOnMessageCallback` (the recommended path), this is handled for you.
+### Migration actions
 
-**`MessageHandleFn` data args also expanded:**
+1. Add `queryId` as the second tuple element for run and stream requests.
+2. Forward `chunkSize` from `StreamMsg` to iterator-capable executors.
+3. Treat `dataEvent` as one raw row, not `QueryResult[]`.
+4. On `CancelMsg`, call `return()` on the active iterator for that `queryId`.
+5. Send the cancellation acknowledgement only after `iterator.return()` has completed.
+6. Suppress the normal stream end message for cancelled streams.
+
+### Reason
+
+The main thread must keep the worker-backed connection promise tied to the real worker execution lifetime. Cancellation acknowledgement prevents local stream cleanup from finishing before the worker has released the underlying SQLite statement.
+
+---
+
+## Rule 8: `MessageHandleFn` uses six positional parameters
+
+### v1 shape
 
 ```ts
-// ❌ v1.2.1
 type MessageHandleFn<DB> = (
   exec: IGenericSqlite<DB>,
   type: string,
@@ -219,8 +256,11 @@ type MessageHandleFn<DB> = (
   data2: unknown,
   data3: unknown,
 ) => Promisable<any>
+```
 
-// ✅ v2
+### v2 shape
+
+```ts
 type MessageHandleFn<DB> = (
   exec: IGenericSqlite<DB>,
   type: string,
@@ -231,129 +271,97 @@ type MessageHandleFn<DB> = (
 ) => Promisable<any>
 ```
 
----
+### Migration action
 
-### Rule 8 — `streamQuery` signature on connections changed
-
-Both `GenericSqliteConnection` and `GenericSqliteWorkerConnection`:
+Update custom message handlers to accept the fourth data argument.
 
 ```ts
-// ❌ v1.2.1
-async *streamQuery<R>(
-  { parameters, query, sql }: CompiledQuery
-): AsyncIterableIterator<QueryResult<R>>
+const handleCustomMessage: MessageHandleFn = async (exec, type, data1, data2, data3, data4) => {
+  return undefined
+}
+```
 
-// ✅ v2
+---
+
+## Rule 9: `streamQuery` accepts `chunkSize` and operation options
+
+### v1 shape
+
+```ts
 async *streamQuery<R>(
-  { parameters, query, sql, queryId }: CompiledQuery,
-  chunkSize?: number,
-  options?: AbortableOperationOptions
+  { parameters, query, sql }: CompiledQuery,
 ): AsyncIterableIterator<QueryResult<R>>
 ```
 
-v2 adds `chunkSize` forwarding and `AbortSignal` support via `options?.signal`. If you implement a custom `DatabaseConnection`, update the signature and wire the abort listener.
+### v2 shape
 
-For worker-backed connections, aborting or closing the async iterator also sends
-`CancelMsg` to the worker so the worker-side iterator can stop and release its
-statement. If you use `GenericSqliteWorkerDialect`, this is already implemented.
-If you wrote your own worker connection, mirror this behavior instead of only
-rejecting the main-thread promise.
+```ts
+async *streamQuery<R>(
+  { parameters, query, sql, queryId }: CompiledQuery,
+  chunkSize?: number,
+  options?: AbortableOperationOptions,
+): AsyncIterableIterator<QueryResult<R>>
+```
+
+### Migration actions
+
+1. Add `queryId` when destructuring the compiled query if your implementation needs stream correlation.
+2. Add `chunkSize?: number`.
+3. Add `options?: AbortableOperationOptions`.
+4. Respect `options.signal` for abort behavior.
+5. For worker-backed streams, use the cancellation acknowledgement protocol from Rule 7.
 
 ---
 
-### Rule 9 — `buildQueryFn` / `buildQueryFnAlt` routing and `IGenericSqliteExecutor.run` behavior changed
+## Rule 10: `buildQueryFn` and `buildQueryFnAlt` route queries differently
 
-Three related changes: `buildQueryFn` now uses AST-aware routing, `buildQueryFnAlt` gained SQL-level detection, and `IGenericSqliteExecutor.run`'s return type expanded to match.
-
-**`IGenericSqliteExecutor.run` return type:**
+### `IGenericSqliteExecutor.run` return type
 
 ```ts
-// ❌ v1.2.1
-interface IGenericSqliteExecutor {
-  run(sql, params): Promisable<Pick<QueryResult<any>, 'insertId' | 'numAffectedRows'>>
-}
-
-// ✅ v2
 interface IGenericSqliteExecutor {
   run(
-    sql,
-    params,
+    sql: string,
+    params: readonly unknown[],
   ): Promisable<Pick<QueryResult<any>, 'insertId' | 'numAffectedRows'> & { rows?: any[] }>
 }
 ```
 
-**`buildQueryFn` routing:**
+### Migration actions
 
-| aspect              | v1.2.1                                              | v2                                              |
-| ------------------- | --------------------------------------------------- | ----------------------------------------------- |
-| Detection           | `isSelect` boolean only                             | `isReadOrReturningQuery(node, sql)` — AST-aware |
-| Write path          | `exec.run('select 1')` for metadata                 | `exec.run(sql, parameters)` with actual SQL     |
-| `returning` support | No (v1 `buildQueryFn` ran everything through `all`) | Yes — Kysely AST RETURNING detected             |
+1. Ensure `run(sql, params)` executes the supplied SQL.
+2. Do not keep v1 implementations that only execute `select 1` for metadata.
+3. If using `buildQueryFn`, forward the AST `node` from `IGenericSqlite.query`.
+4. If using `buildQueryFnAlt`, verify raw SQL `SELECT` statements work when routed through `all`.
 
-```ts
-// ❌ v1.2.1 — buildQueryFn sent ALL queries through exec.all
-// ✅ v2 — buildQueryFn routes: read/returning → exec.all, write → exec.run
-```
+### Routing changes
 
-If your `run` implementation already executes the SQL and returns metadata from it, **no change needed** — the extra `rows` property is optional. However, v1's `buildQueryFn` called `exec.run('select 1')` (a dummy query that only fetched `last_insert_rowid` and `changes` without executing the real SQL). In v2, `buildQueryFn` calls `exec.run(sql, parameters)` — your `run` implementation must now **execute the actual SQL** and return the resulting metadata.
-
-**`buildQueryFnAlt` routing also enhanced:**
-
-`buildQueryFnAlt` is a simpler alternative that does **not** support Kysely AST `returning` detection. Its detection logic was also broadened:
-
-```ts
-// ❌ v1.2.1 — pure boolean routing
-return async (isSelect, sql, parameters) =>
-  isSelect
-    ? { rows: await exec.all(sql, parameters) }
-    : { rows: [], ...(await exec.run(sql, parameters)) }
-
-// ✅ v2 — boolean + SQL prefix routing
-return async (isSelect, sql, parameters) =>
-  isSelect || sql.toLowerCase().startsWith('select')
-    ? { rows: await exec.all(sql, parameters) }
-    : { rows: [], ...(await exec.run(sql, parameters)) }
-```
-
-The `sql.toLowerCase().startsWith('select')` guard catches raw SQL `SELECT` statements that arrive with `isSelect === false`. In practice this is safe — `all` is a superset of `run` — but if your `all` and `run` implementations have materially different side effects, verify that raw SELECTs routed through `all` still work as expected.
+| Helper            | v1 behavior                  | v2 behavior                                       |
+| ----------------- | ---------------------------- | ------------------------------------------------- |
+| `buildQueryFn`    | Mostly `isSelect`-driven     | Uses AST/text detection for read/returning SQL    |
+| `buildQueryFnAlt` | `isSelect`-driven            | Uses `isSelect` plus SQL `select` prefix fallback |
+| write path        | metadata workaround possible | executes the real write SQL                       |
 
 ---
 
-### Rule 10 — New exports (add to imports)
+## Rule 11: Prefer documented public exports
 
-These were internal or absent in v1.2.1 and are now public:
+### Public exports added or promoted in v2
 
-| Export                   | Import from                    | Purpose                                                |
-| ------------------------ | ------------------------------ | ------------------------------------------------------ |
-| `access`                 | `kysely-generic-sqlite`        | Resolve `T \| (() => Promisable<T>)` to `Promise<T>`   |
-| `isReadOrReturningQuery` | `kysely-generic-sqlite`        | Detect SELECT / PRAGMA / VALUES / WITH / RETURNING     |
-| `SqliteExecutorFactory`  | `kysely-generic-sqlite`        | Type for `(options?) => Promisable<T>`                 |
-| Worker protocol messages | `kysely-generic-sqlite/worker` | Types and event constants for custom worker transports |
+| Export                   | Import from                    | Purpose                             |
+| ------------------------ | ------------------------------ | ----------------------------------- |
+| `access`                 | `kysely-generic-sqlite`        | Resolve lazy values to `Promise<T>` |
+| `isReadOrReturningQuery` | `kysely-generic-sqlite`        | Detect read or returning SQL        |
+| `SqliteExecutorFactory`  | `kysely-generic-sqlite`        | Type executor factories             |
+| Worker protocol exports  | `kysely-generic-sqlite/worker` | Build custom worker transports      |
 
-The `access` helper replaces the common v1 pattern:
+### Migration action
+
+Replace duplicated lazy-resolution code when appropriate:
 
 ```ts
-// ❌ v1.2.1
-const db = typeof config.database === 'function' ? await config.database() : config.database
-
-// ✅ v2
 import { access } from 'kysely-generic-sqlite'
+
 const db = await access(config.database)
 ```
 
----
-
-### Quick migration checklist
-
-- [ ] `package.json`: bump `kysely` peer to `>=0.29`
-- [ ] Remove any `releaseConnection()` calls that expected unlocking behavior
-- [ ] If extending `BaseSqliteDriver`: update `init` to accept `(options?)`; do not override `releaseConnection`
-- [ ] `IGenericSqlite.query`: change `parameters?` → `parameters` (required); add 4th `node?` parameter
-- [ ] `OnCreateConnection` callbacks: add second `options?` parameter
-- [ ] Executor factories: accept `options?` parameter (or use `SqliteExecutorFactory<T>`)
-- [ ] Worker `onmessage` handlers: update tuple destructuring for `queryId` position
-- [ ] Custom worker stream protocol: handle `CancelMsg` and call `return()` on the active iterator
-- [ ] Custom `MessageHandleFn`: add 4th data arg
-- [ ] Custom `DatabaseConnection.streamQuery`: add `chunkSize?` and `options?` parameters
-- [ ] Replace `typeof x === 'function' ? await x() : x` with `await access(x)`
-- [ ] If using `buildQueryFn`: ensure `run` handles the real write SQL, not just `'select 1'`
+Avoid deep imports from `dist` or package-internal source files.

--- a/packages/dialect-generic-sqlite/MIGRATE_TO_V2.md
+++ b/packages/dialect-generic-sqlite/MIGRATE_TO_V2.md
@@ -2,6 +2,13 @@
 
 Scope: this document only covers `kysely-generic-sqlite`. It is written for automated migration agents and humans reviewing their changes.
 
+> [!important]
+> The worker protocol was replaced during the v2 beta. Numeric tuple events,
+> `mitt`, and `MessageHandleFn` no longer exist. Use the exported tagged
+> `WorkerRequest`/`WorkerResponse` types, `WorkerRequestHandler`, and
+> `GenericSqliteWorkerConnection.request()` instead. The built-in Node and Web
+> helpers implement the protocol and should be preferred over manual transport code.
+
 ## Agent workflow
 
 1. Read the repository's package manager files and TypeScript sources.

--- a/packages/dialect-generic-sqlite/README.md
+++ b/packages/dialect-generic-sqlite/README.md
@@ -169,14 +169,11 @@ To create a dialect that run SQLs in web worker, you can use built-in dialect `G
 ```ts
 import { GenericSqliteWorkerDialect } from 'kysely-generic-sqlite/worker'
 import { createWebWorkerExecutor } from 'kysely-generic-sqlite/worker-helper-web'
-import { mitt } from 'zen-mitt'
 
 const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
 const dialect = new GenericSqliteWorkerDialect(
   createWebWorkerExecutor({
     worker,
-    // Event Emitter to handle worker messages
-    mitt: mitt(),
     // Optional extra data.
     data: { fileName: ':memory:' },
   }),
@@ -205,67 +202,32 @@ createWebOnMessageCallback<{ fileName: string }>((data) => {
 })
 ```
 
-### Worker Stream Cancellation
+### Worker Streams And Custom Requests
 
-`GenericSqliteWorkerDialect` cancels active worker streams when a stream is aborted,
-closed early, or the connection is closed. The built-in
-`createNodeOnMessageCallback` and `createWebOnMessageCallback` helpers handle
-this automatically.
+Worker streams use pull-based batches, so at most one batch is in flight. The
+built-in helpers cancel and release active iterators when a stream is aborted,
+closed early, or the connection is destroyed.
 
-If you implement the worker protocol manually, handle the `cancelEvent` message
-and call `return()` on the active iterator for the matching query id:
+For custom worker RPC, pass a `WorkerRequestHandler` to the worker helper and
+capture the `GenericSqliteWorkerConnection` from `onCreateConnection`:
 
 ```ts
-import { cancelEvent } from 'kysely-generic-sqlite/worker'
+import {
+  GenericSqliteWorkerConnection,
+  type WorkerRequestHandler,
+} from 'kysely-generic-sqlite/worker'
 
-const activeStreams = new Map<string, AsyncIterator<unknown> | Iterator<unknown>>()
-
-async function onMessage([type, queryId]: [string, string]) {
-  if (type === cancelEvent) {
-    await activeStreams.get(queryId)?.return?.()
-    activeStreams.delete(queryId)
-  }
+const custom: WorkerRequestHandler = (exec, { type, payload }) => {
+  if (type === 'optimize') return exec.db.pragma('optimize')
+  throw new Error(`Unknown request: ${type}`)
 }
-```
 
-### Send Custom Messages To Worker
-
-dialect:
-
-```ts
-import { GenericSqliteWorkerDialect } from 'kysely-generic-sqlite/worker'
-import { createNodeMitt, handleNodeWorker } from 'kysely-generic-sqlite/worker-helper-node'
-
-const outer = createNodeMitt()
-const dialect = new GenericSqliteWorkerDialect(async () => {
-  const m = createNodeMitt()
-  m.on('test', console.log)
-  outer.on('call-test', () => m.emit('test', 'your-data'))
-  return {
-    worker: new Worker('./worker.js'),
-    mitt: m,
-    handle: handleNodeWorker,
-  }
+let connection: GenericSqliteWorkerConnection
+const dialect = new GenericSqliteWorkerDialect(createNodeWorkerExecutor({ worker }), (conn) => {
+  connection = conn as GenericSqliteWorkerConnection
 })
-```
 
-in `worker.ts`
-
-```ts
-import type { Database } from 'better-sqlite3'
-
-import { createNodeOnMessageCallback } from 'kysely-generic-sqlite/worker-helper-node'
-
-createNodeOnMessageCallback<{}, Database>(
-  (data) => createSqliteExecutor(':memory:'),
-  (exec, type, data1, data2, data3, data4) => {
-    if (type === 'test') {
-      exec.db.pragma('optimize')
-      console.log(data1) // 'your-data'
-      return 'CUSTOM'
-    }
-  },
-)
+await connection.request('optimize', { source: 'ui' })
 ```
 
 ### Use Basic Dialect

--- a/packages/dialect-generic-sqlite/package.json
+++ b/packages/dialect-generic-sqlite/package.json
@@ -31,13 +31,13 @@
   "typesVersions": {
     "*": {
       "worker": [
-        "./dist/worker.d.ts"
+        "./dist/worker.d.mts"
       ],
       "worker-helper-node": [
-        "./dist/worker-helper-node.d.ts"
+        "./dist/worker-helper-node.d.mts"
       ],
       "worker-helper-web": [
-        "./dist/worker-helper-web.d.ts"
+        "./dist/worker-helper-web.d.mts"
       ]
     }
   },

--- a/packages/dialect-generic-sqlite/src/base.ts
+++ b/packages/dialect-generic-sqlite/src/base.ts
@@ -25,6 +25,25 @@ import {
 
 import type { IGenericSqlite, IGenericSqliteExecutor, Promisable } from './type'
 
+export type QueryClassification = 'read' | 'write'
+
+export interface QueryClassifierContext {
+  isSelect: boolean
+  node?: RootOperationNode
+  sql: string
+}
+
+export type QueryClassifier = (context: QueryClassifierContext) => QueryClassification | undefined
+
+export interface BuildQueryFnOptions {
+  /**
+   * Classifies raw SQL that Kysely's AST cannot decide. SQLite PRAGMA, WITH and
+   * raw SQL are intentionally not parsed by this package; provide this callback
+   * when their default prefix heuristic is not appropriate for your executor.
+   */
+  classifyQuery?: QueryClassifier
+}
+
 export class BaseSqliteDialect implements Dialect {
   /**
    * Base class that implements {@link Dialect}
@@ -147,9 +166,12 @@ export async function access<T>(data: T | (() => Promisable<T>)): Promise<T> {
  * When `isSelectQueryNode` is true or sql starts with `select`, call `exec.all`, otherwise call `exec.run`.
  * This is a simple implementation that does not support `returning`.
  */
-export function buildQueryFnAlt(exec: IGenericSqliteExecutor): IGenericSqlite['query'] {
-  return async (isSelect, sql, parameters) =>
-    isSelect || sql.toLowerCase().startsWith('select')
+export function buildQueryFnAlt(
+  exec: IGenericSqliteExecutor,
+  options: BuildQueryFnOptions = {},
+): IGenericSqlite['query'] {
+  return async (isSelect, sql, parameters, node) =>
+    isReadQuery(isSelect, node, sql, options)
       ? { rows: await exec.all(sql, parameters) }
       : { rows: [], ...(await exec.run(sql, parameters)) }
 }
@@ -164,9 +186,12 @@ export function buildQueryFnAlt(exec: IGenericSqliteExecutor): IGenericSqlite['q
  * `INSERT`, `UPDATE`, or `DELETE` statements with a `RETURNING` clause are
  * treated as write queries and executed with `exec.run`.
  */
-export function buildQueryFn(exec: IGenericSqliteExecutor): IGenericSqlite['query'] {
-  return async (_isSelect, sql, parameters, node) => {
-    if (isReadOrReturningQuery(node, sql)) {
+export function buildQueryFn(
+  exec: IGenericSqliteExecutor,
+  options: BuildQueryFnOptions = {},
+): IGenericSqlite['query'] {
+  return async (isSelect, sql, parameters, node) => {
+    if (isReadOrReturningQuery(node, sql, isSelect, options)) {
       const rows = await exec.all(sql, parameters)
       return { rows }
     }
@@ -187,18 +212,35 @@ export function parseBigInt(num: number | bigint | null | undefined): bigint | u
  *
  * Limitation: raw SQL `returning` clauses are not inspected.
  */
-export function isReadOrReturningQuery(node: RootOperationNode | undefined, sql: string): boolean {
+export function isReadOrReturningQuery(
+  node: RootOperationNode | undefined,
+  sql: string,
+  isSelect = false,
+  options: BuildQueryFnOptions = {},
+): boolean {
   if (node) {
     if (SelectQueryNode.is(node)) {
       return true
     }
-    if (
-      (InsertQueryNode.is(node) || UpdateQueryNode.is(node) || DeleteQueryNode.is(node)) &&
-      node.returning
-    ) {
-      return true
+    if (InsertQueryNode.is(node) || UpdateQueryNode.is(node) || DeleteQueryNode.is(node)) {
+      return Boolean(node.returning)
     }
   }
+  return isReadQuery(isSelect, undefined, sql, options)
+}
 
+function isReadQuery(
+  isSelect: boolean,
+  node: RootOperationNode | undefined,
+  sql: string,
+  options: BuildQueryFnOptions,
+): boolean {
+  if (isSelect || (node && SelectQueryNode.is(node))) {
+    return true
+  }
+  const classification = options.classifyQuery?.({ isSelect, node, sql })
+  if (classification) {
+    return classification === 'read'
+  }
   return /^\s*(select|pragma|values|with)\b/i.test(sql)
 }

--- a/packages/dialect-generic-sqlite/src/type.ts
+++ b/packages/dialect-generic-sqlite/src/type.ts
@@ -62,6 +62,12 @@ export interface IGenericSqlite<DB = unknown> {
   close: () => Promisable<any>
 
   /**
+   * Interrupts the currently executing query when the underlying SQLite
+   * implementation supports it.
+   */
+  cancelQuery?: () => Promisable<void>
+
+  /**
    * Basic function for executing SQL queries and get query result
    * @param isSelect Whether the sql is SELECT query
    * @param sql The SQL query string to execute.

--- a/packages/dialect-generic-sqlite/src/worker/driver.ts
+++ b/packages/dialect-generic-sqlite/src/worker/driver.ts
@@ -1,6 +1,7 @@
 import type {
   AbortableOperationOptions,
   CompiledQuery,
+  ControlConnectionProvider,
   DatabaseConnection,
   QueryResult,
 } from 'kysely'
@@ -10,341 +11,253 @@ import { BaseSqliteDriver } from '../base'
 import type { OnCreateConnection, SqliteExecutorFactory } from '../type'
 
 import type {
-  CancelMsg,
-  CloseMsg,
-  IGenericEventEmitter,
   IGenericSqliteWorkerExecutor,
   IGenericWorker,
-  InitMsg,
-  RunMsg,
-  StreamMsg,
+  WorkerRequest,
+  WorkerResponse,
 } from './types'
-import {
-  cancelAckEvent,
-  cancelEvent,
-  closeEvent,
-  dataEvent,
-  endEvent,
-  initEvent,
-  runEvent,
-} from './types'
+import { deserializeWorkerError } from './utils'
 
-/**
- * {@link Driver} that dispatches queries to a worker thread.
- *
- * @template T - the worker type
- * @template R - extra init data shape
- */
+type Pending = {
+  resolve: (response: Exclude<WorkerResponse, { type: 'error' }>) => void
+  reject: (error: Error) => void
+}
+type OutgoingRequest = WorkerRequest extends infer U
+  ? U extends { id: string }
+    ? Omit<U, 'id'> & { id?: string }
+    : never
+  : never
+
 export class GenericSqliteWorkerDriver<
   T extends IGenericWorker,
   R extends Record<string, unknown>,
 > extends BaseSqliteDriver {
   private worker?: T
-  private mitt?: IGenericEventEmitter
+  private connection?: GenericSqliteWorkerConnection
+  private dispose?: () => void
+  private closing?: Promise<void>
+
   constructor(
     executor: SqliteExecutorFactory<IGenericSqliteWorkerExecutor<T, R>>,
     onCreateConnection?: OnCreateConnection,
   ) {
     super(async (options) => {
-      const exec = await executor(options)
-      this.mitt = exec.mitt
-      this.worker = exec.worker
-
-      exec.handle(this.worker, ([type, ...msg]) => this.mitt!.emit(type, ...msg))
-
-      const initAck = new Promise<void>((resolve, reject) => {
-        this.mitt!.once(initEvent, (_qid, _data, err) => (err ? reject(err) : resolve()))
-      })
-
-      this.worker.postMessage([initEvent, exec.data || ({} as any)] satisfies InitMsg<R>)
-
-      await initAck
-
-      this.conn = new GenericSqliteWorkerConnection(this.worker, this.mitt)
-      await onCreateConnection?.(this.conn, options)
+      let exec: IGenericSqliteWorkerExecutor<T, R> | undefined
+      try {
+        exec = await executor(options)
+        this.worker = exec.worker
+        this.connection = new GenericSqliteWorkerConnection(exec.worker)
+        this.dispose = exec.handle(exec.worker, {
+          message: (message) => this.connection?.handle(message),
+          error: (error) => this.connection?.fail(error),
+          close: (error) => this.connection?.fail(error ?? new Error('Worker closed')),
+        })
+        const ready = await this.connection.send({ type: 'init', data: exec.data ?? ({} as R) })
+        if (ready.type !== 'ready') {
+          throw new Error('Invalid worker initialization response')
+        }
+        this.connection.enableCancellation(ready.canCancelQuery)
+        this.conn = this.connection
+        await onCreateConnection?.(this.connection, options)
+      } catch (error) {
+        this.connection?.fail(error)
+        this.dispose?.()
+        this.dispose = undefined
+        await this.worker?.terminate()
+        this.worker = undefined
+        this.connection = undefined
+        this.conn = undefined
+        throw error
+      }
     })
   }
 
   async destroy(): Promise<void> {
-    if (!this.worker) {
+    this.closing ??= this.destroyInner()
+    return this.closing
+  }
+
+  private async destroyInner(): Promise<void> {
+    const connection = this.connection
+    const worker = this.worker
+    try {
+      await connection?.close()
+    } finally {
+      this.dispose?.()
+      this.dispose = undefined
+      await worker?.terminate()
+      this.worker = undefined
+      this.connection = undefined
+      this.conn = undefined
+    }
+  }
+}
+
+export class GenericSqliteWorkerConnection implements DatabaseConnection {
+  private readonly pending = new Map<string, Pending>()
+  private readonly streams = new Set<string>()
+  private sequence = 0
+  private failed?: Error
+  private closing?: Promise<void>
+  private activeExecute?: string
+  cancelQuery?: (controlConnectionProvider: ControlConnectionProvider) => Promise<void>
+
+  constructor(private readonly worker: IGenericWorker) {}
+
+  enableCancellation(enabled: boolean): void {
+    if (!enabled) {
       return
     }
-    const closeAck = new Promise<void>((resolve, reject) =>
-      this.mitt?.once(closeEvent, (_qid, _data, err) => (err ? reject(err) : resolve())),
-    )
-
-    this.worker.postMessage([closeEvent] satisfies CloseMsg)
-
-    return closeAck.finally(() => {
-      ;(this.conn as GenericSqliteWorkerConnection)?.close()
-      this.worker?.terminate()
-      this.mitt?.off()
-      this.mitt = this.worker = undefined
-    })
-  }
-}
-
-type PendingRun = { resolve: (data: any) => void; reject: (err: any) => void }
-type StreamResult<R> = [data: QueryResult<R> | undefined, done: boolean]
-type PendingStream = {
-  queue: StreamResult<any>[]
-  wait?: PendingRun
-  error?: unknown
-  completed?: boolean
-  canceled?: boolean
-  cancelAck?: Promise<void>
-  resolveCancelAck?: () => void
-}
-
-/**
- * {@link DatabaseConnection} that communicates with a worker thread.
- *
- * Supports both `executeQuery` and `streamQuery`.
- */
-class GenericSqliteWorkerConnection implements DatabaseConnection {
-  private pendingRuns = new Map<string, PendingRun>()
-  private pendingStreams = new Map<string, PendingStream>()
-
-  constructor(
-    readonly worker: IGenericWorker,
-    readonly mitt: IGenericEventEmitter,
-  ) {
-    // Central dispatcher — register once, route by queryId
-    this.mitt.on(runEvent, (queryId: string | undefined, data: any, err: unknown) => {
-      if (!queryId) {
-        return
+    this.cancelQuery = async () => {
+      const id = this.activeExecute
+      if (id) {
+        await this.send({ type: 'cancel', target: 'query', queryId: id })
       }
-      const pending = this.pendingRuns.get(queryId)
-      if (!pending) {
-        return
-      }
-      this.pendingRuns.delete(queryId)
-      if (err) {
-        pending.reject(err)
-      } else {
-        pending.resolve(data)
-      }
-    })
-
-    this.mitt.on(dataEvent, (queryId: string | undefined, data: any, err: unknown) => {
-      if (!queryId) {
-        return
-      }
-      const state = this.pendingStreams.get(queryId)
-      if (!state) {
-        return
-      }
-      if (err) {
-        this.rejectStream(queryId, state, err)
-      } else {
-        this.pushStreamResult(queryId, state, [{ rows: [data] }, false])
-      }
-    })
-
-    this.mitt.on(endEvent, (queryId: string | undefined, _data: any, err: unknown) => {
-      if (!queryId) {
-        return
-      }
-      const state = this.pendingStreams.get(queryId)
-      if (!state) {
-        return
-      }
-      if (err) {
-        this.rejectStream(queryId, state, err)
-      } else {
-        this.pushStreamResult(queryId, state, [undefined, true])
-      }
-    })
-
-    this.mitt.on(cancelAckEvent, (queryId: string | undefined, _data: any, err: unknown) => {
-      if (!queryId) {
-        return
-      }
-      const state = this.pendingStreams.get(queryId)
-      if (!state) {
-        return
-      }
-      this.resolveStreamCancellation(state, err)
-    })
+    }
   }
 
-  close(): void {
-    const err = new Error('Connection closed')
-    for (const [, pending] of this.pendingRuns) {
-      pending.reject(err)
+  handle(response: WorkerResponse): void {
+    const pending = this.pending.get(response.id)
+    if (!pending) {
+      return
     }
-    this.pendingRuns.clear()
-    for (const [queryId, state] of this.pendingStreams) {
-      this.cancelStream(queryId, state)
-      this.rejectStream(queryId, state, err)
-      this.resolveStreamCancellation(state, err)
+    if (response.type === 'error') {
+      this.pending.delete(response.id)
+      pending.reject(deserializeWorkerError(response.error))
+      return
     }
-    this.pendingStreams.clear()
+    this.pending.delete(response.id)
+    pending.resolve(response)
+  }
+
+  fail(error: unknown): void {
+    if (this.failed) {
+      return
+    }
+    this.failed = error instanceof Error ? error : new Error(String(error))
+    for (const pending of this.pending.values()) {
+      pending.reject(this.failed)
+    }
+    this.pending.clear()
+  }
+
+  async executeQuery<R>(compiledQuery: CompiledQuery<unknown>): Promise<QueryResult<R>> {
+    const { parameters, sql, query } = compiledQuery
+    const response = await this.send({
+      type: 'execute',
+      isSelect: SelectQueryNode.is(query),
+      sql,
+      parameters,
+    })
+    if (response.type !== 'result') {
+      throw new Error('Invalid execute response')
+    }
+    return response.result as QueryResult<R>
   }
 
   async *streamQuery<R>(
     { parameters, sql, query, queryId }: CompiledQuery,
-    chunkSize?: number,
-    options?: AbortableOperationOptions,
+    chunkSize: number,
+    _options?: AbortableOperationOptions,
   ): AsyncIterableIterator<QueryResult<R>> {
-    if (options?.signal?.aborted) {
-      return
+    if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+      throw new RangeError('chunkSize must be a positive integer')
     }
-
-    const streamState: PendingStream = { queue: [] }
-    this.pendingStreams.set(queryId.queryId, streamState)
-
+    const id = queryId.queryId
+    this.streams.add(id)
+    let done = false
     try {
-      this.worker.postMessage([
-        dataEvent,
-        queryId.queryId,
-        SelectQueryNode.is(query),
+      let response = await this.send({
+        type: 'stream',
+        streamId: id,
+        isSelect: SelectQueryNode.is(query),
         sql,
         parameters,
         chunkSize,
-      ] satisfies StreamMsg)
-    } catch (error) {
-      this.pendingStreams.delete(queryId.queryId)
-      throw error
-    }
-
-    const onAbort = (): void => {
-      this.cancelStream(queryId.queryId, streamState)
-      this.rejectStream(queryId.queryId, streamState, new Error('Query aborted'))
-    }
-    options?.signal?.addEventListener('abort', onAbort, { once: true })
-
-    try {
+      })
       while (true) {
-        const [data, isDone] = await this.nextStreamResult<R>(streamState)
-
-        if (isDone) {
+        if (response.type !== 'stream') {
+          throw new Error('Invalid stream response')
+        }
+        if (response.rows.length) {
+          yield { rows: response.rows as R[] }
+        }
+        done = response.done
+        if (done) {
           return
         }
-        yield data!
+        response = await this.send({ type: 'pull', streamId: id, chunkSize })
       }
     } finally {
-      options?.signal?.removeEventListener('abort', onAbort)
-      await this.cancelStream(queryId.queryId, streamState)
-      this.pendingStreams.delete(queryId.queryId)
-    }
-  }
-
-  async executeQuery<R>(
-    compiledQuery: CompiledQuery<unknown>,
-    options?: AbortableOperationOptions,
-  ): Promise<QueryResult<R>> {
-    const { parameters, sql, query, queryId } = compiledQuery
-    if (options?.signal?.aborted) {
-      throw new Error('Query aborted')
-    }
-
-    const queryKey = queryId.queryId
-    return new Promise((resolve, reject) => {
-      let cleanup = (): void => {}
-      // After dispatch, this promise represents the actual worker execution lifetime.
-      // Rejecting it on abort would let Kysely release the single-connection mutex
-      // while SQLite may still be executing in the worker. Kysely races the user-facing
-      // operation against the AbortSignal; this underlying promise settles only when
-      // the worker sends its success/error response.
-      const onAbort = (): void => {}
-      cleanup = (): void => {
-        this.pendingRuns.delete(queryKey)
-        options?.signal?.removeEventListener('abort', onAbort)
-      }
-      const settle =
-        <T>(callback: (value: T) => void) =>
-        (value: T): void => {
-          cleanup()
-          callback(value)
+      this.streams.delete(id)
+      if (!done && !this.failed) {
+        try {
+          await this.send({ type: 'cancel', target: 'stream', streamId: id })
+        } catch {
+          // Preserve the original stream error or cancellation reason.
         }
-
-      this.pendingRuns.set(queryKey, {
-        resolve: settle(resolve),
-        reject: settle(reject),
-      })
-      options?.signal?.addEventListener('abort', onAbort, { once: true })
-
-      try {
-        this.worker.postMessage([
-          runEvent,
-          queryKey,
-          SelectQueryNode.is(query),
-          sql,
-          parameters,
-        ] satisfies RunMsg)
-      } catch (error) {
-        cleanup()
-        reject(error)
       }
-    })
+    }
   }
 
-  private nextStreamResult<R>(state: PendingStream): Promise<StreamResult<R>> {
-    const queued = state.queue.shift()
-    if (queued) {
-      return Promise.resolve(queued)
+  async request<T = unknown>(type: string, payload?: unknown): Promise<T> {
+    const response = await this.send({ type: 'custom', name: type, payload })
+    if (response.type !== 'custom') {
+      throw new Error('Invalid custom response')
     }
-    if (state.error) {
-      return Promise.reject(state.error)
-    }
-    return new Promise((resolve, reject) => {
-      state.wait = { resolve, reject }
-    })
+    return response.result as T
   }
 
-  private pushStreamResult(queryId: string, state: PendingStream, result: StreamResult<any>): void {
-    if (result[1]) {
-      state.completed = true
-    }
-    if (state.wait) {
-      const { resolve } = state.wait
-      state.wait = undefined
-      resolve(result)
+  async close(): Promise<void> {
+    this.closing ??= this.closeInner()
+    return this.closing
+  }
+
+  private async closeInner(): Promise<void> {
+    await Promise.all(
+      [...this.streams].map(
+        async (streamId) => await this.send({ type: 'cancel', target: 'stream', streamId }),
+      ),
+    )
+    if (this.failed) {
       return
     }
-    state.queue.push(result)
-    if (result[1]) {
-      this.pendingStreams.delete(queryId)
+    const response = await this.send({ type: 'close' })
+    if (response.type !== 'closed') {
+      throw new Error('Invalid close response')
     }
   }
 
-  private cancelStream(queryId: string, state: PendingStream): Promise<void> {
-    if (state.completed || state.canceled) {
-      return state.cancelAck ?? Promise.resolve()
+  send(message: OutgoingRequest): Promise<Exclude<WorkerResponse, { type: 'error' }>> {
+    if (this.failed) {
+      return Promise.reject(this.failed)
     }
-    state.canceled = true
-    state.cancelAck = new Promise<void>((resolve) => {
-      state.resolveCancelAck = resolve
+    const id = message.id ?? `generic-sqlite-${++this.sequence}`
+    const request = { ...message, id } as WorkerRequest
+    if (request.type === 'execute') {
+      this.activeExecute = id
+    }
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: (response) => {
+          if (this.activeExecute === id) {
+            this.activeExecute = undefined
+          }
+          resolve(response)
+        },
+        reject: (error) => {
+          if (this.activeExecute === id) {
+            this.activeExecute = undefined
+          }
+          reject(error)
+        },
+      })
+      try {
+        this.worker.postMessage(request)
+      } catch (error) {
+        this.pending.delete(id)
+        this.fail(error)
+      }
     })
-    try {
-      this.worker.postMessage([cancelEvent, queryId] satisfies CancelMsg)
-    } catch {
-      // Ignore cancellation delivery failures so cleanup never masks the original stream result.
-      this.resolveStreamCancellation(state)
-    }
-    return state.cancelAck
-  }
-
-  private rejectStream(queryId: string, state: PendingStream, err: unknown): void {
-    if (!state.canceled) {
-      this.pendingStreams.delete(queryId)
-    }
-    state.completed = true
-    state.queue.length = 0
-    state.error = err
-    if (state.wait) {
-      const { reject } = state.wait
-      state.wait = undefined
-      reject(err)
-    }
-  }
-
-  private resolveStreamCancellation(state: PendingStream, _err?: unknown): void {
-    // Cancellation acknowledgements are cleanup bookkeeping. Resolve even if the
-    // worker reports an error or is shutting down so iterator cleanup cannot hang
-    // or replace the stream's original result/error.
-    state.resolveCancelAck?.()
-    state.resolveCancelAck = undefined
   }
 }

--- a/packages/dialect-generic-sqlite/src/worker/driver.ts
+++ b/packages/dialect-generic-sqlite/src/worker/driver.ts
@@ -19,7 +19,15 @@ import type {
   RunMsg,
   StreamMsg,
 } from './types'
-import { cancelEvent, closeEvent, dataEvent, endEvent, initEvent, runEvent } from './types'
+import {
+  cancelAckEvent,
+  cancelEvent,
+  closeEvent,
+  dataEvent,
+  endEvent,
+  initEvent,
+  runEvent,
+} from './types'
 
 /**
  * {@link Driver} that dispatches queries to a worker thread.
@@ -84,6 +92,8 @@ type PendingStream = {
   error?: unknown
   completed?: boolean
   canceled?: boolean
+  cancelAck?: Promise<void>
+  resolveCancelAck?: () => void
 }
 
 /**
@@ -145,6 +155,17 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
         this.pushStreamResult(queryId, state, [undefined, true])
       }
     })
+
+    this.mitt.on(cancelAckEvent, (queryId: string | undefined, _data: any, err: unknown) => {
+      if (!queryId) {
+        return
+      }
+      const state = this.pendingStreams.get(queryId)
+      if (!state) {
+        return
+      }
+      this.resolveStreamCancellation(state, err)
+    })
   }
 
   close(): void {
@@ -156,7 +177,9 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
     for (const [queryId, state] of this.pendingStreams) {
       this.cancelStream(queryId, state)
       this.rejectStream(queryId, state, err)
+      this.resolveStreamCancellation(state, err)
     }
+    this.pendingStreams.clear()
   }
 
   async *streamQuery<R>(
@@ -171,14 +194,19 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
     const streamState: PendingStream = { queue: [] }
     this.pendingStreams.set(queryId.queryId, streamState)
 
-    this.worker.postMessage([
-      dataEvent,
-      queryId.queryId,
-      SelectQueryNode.is(query),
-      sql,
-      parameters,
-      chunkSize,
-    ] satisfies StreamMsg)
+    try {
+      this.worker.postMessage([
+        dataEvent,
+        queryId.queryId,
+        SelectQueryNode.is(query),
+        sql,
+        parameters,
+        chunkSize,
+      ] satisfies StreamMsg)
+    } catch (error) {
+      this.pendingStreams.delete(queryId.queryId)
+      throw error
+    }
 
     const onAbort = (): void => {
       this.cancelStream(queryId.queryId, streamState)
@@ -197,7 +225,7 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
       }
     } finally {
       options?.signal?.removeEventListener('abort', onAbort)
-      this.cancelStream(queryId.queryId, streamState)
+      await this.cancelStream(queryId.queryId, streamState)
       this.pendingStreams.delete(queryId.queryId)
     }
   }
@@ -211,13 +239,15 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
       throw new Error('Query aborted')
     }
 
+    const queryKey = queryId.queryId
     return new Promise((resolve, reject) => {
-      const queryKey = queryId.queryId
       let cleanup = (): void => {}
-      const onAbort = (): void => {
-        cleanup()
-        reject(new Error('Query aborted'))
-      }
+      // After dispatch, this promise represents the actual worker execution lifetime.
+      // Rejecting it on abort would let Kysely release the single-connection mutex
+      // while SQLite may still be executing in the worker. Kysely races the user-facing
+      // operation against the AbortSignal; this underlying promise settles only when
+      // the worker sends its success/error response.
+      const onAbort = (): void => {}
       cleanup = (): void => {
         this.pendingRuns.delete(queryKey)
         options?.signal?.removeEventListener('abort', onAbort)
@@ -279,20 +309,28 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
     }
   }
 
-  private cancelStream(queryId: string, state: PendingStream): void {
+  private cancelStream(queryId: string, state: PendingStream): Promise<void> {
     if (state.completed || state.canceled) {
-      return
+      return state.cancelAck ?? Promise.resolve()
     }
     state.canceled = true
+    state.cancelAck = new Promise<void>((resolve) => {
+      state.resolveCancelAck = resolve
+    })
     try {
       this.worker.postMessage([cancelEvent, queryId] satisfies CancelMsg)
     } catch {
       // Ignore cancellation delivery failures so cleanup never masks the original stream result.
+      this.resolveStreamCancellation(state)
     }
+    return state.cancelAck
   }
 
   private rejectStream(queryId: string, state: PendingStream, err: unknown): void {
-    this.pendingStreams.delete(queryId)
+    if (!state.canceled) {
+      this.pendingStreams.delete(queryId)
+    }
+    state.completed = true
     state.queue.length = 0
     state.error = err
     if (state.wait) {
@@ -300,5 +338,13 @@ class GenericSqliteWorkerConnection implements DatabaseConnection {
       state.wait = undefined
       reject(err)
     }
+  }
+
+  private resolveStreamCancellation(state: PendingStream, _err?: unknown): void {
+    // Cancellation acknowledgements are cleanup bookkeeping. Resolve even if the
+    // worker reports an error or is shutting down so iterator cleanup cannot hang
+    // or replace the stream's original result/error.
+    state.resolveCancelAck?.()
+    state.resolveCancelAck = undefined
   }
 }

--- a/packages/dialect-generic-sqlite/src/worker/index.ts
+++ b/packages/dialect-generic-sqlite/src/worker/index.ts
@@ -1,20 +1,4 @@
 export * from './dialect'
 export * from './driver'
-export { access } from './utils'
-export { cancelEvent, closeEvent, dataEvent, endEvent, initEvent, runEvent } from './types'
-export type {
-  CancelMsg,
-  CloseMsg,
-  HandleMessageFn,
-  IGenericEventEmitter,
-  IGenericSqliteWorkerExecutor,
-  IGenericWorker,
-  InitMsg,
-  InitFn,
-  MainToWorkerMsg,
-  MessageHandleFn,
-  RunMsg,
-  StreamMsg,
-  WorkerToMainMsg,
-} from './types'
 export * from './utils'
+export type * from './types'

--- a/packages/dialect-generic-sqlite/src/worker/node-helper.ts
+++ b/packages/dialect-generic-sqlite/src/worker/node-helper.ts
@@ -1,65 +1,44 @@
-import { EventEmitter } from 'node:events'
 import type { Worker } from 'node:worker_threads'
 import { parentPort } from 'node:worker_threads'
 
 import type { Promisable } from '../type'
 
 import type {
-  HandleMessageFn,
-  IGenericEventEmitter,
+  HandleWorkerFn,
   IGenericSqliteWorkerExecutor,
   InitFn,
-  MessageHandleFn,
+  WorkerRequestHandler,
 } from './types'
 import { access, createGenericOnMessageCallback } from './utils'
 
-/**
- * Wraps a Node.js `EventEmitter` to conform to {@link IGenericEventEmitter}.
- */
-class NodeEventEmitterWrapper extends EventEmitter {
-  override off(eventName?: string | symbol): this {
-    return this.removeAllListeners(eventName)
-  }
-}
-
-/**
- * Register the generic message callback on a Node.js worker thread's
- * `parentPort`.
- */
 export function createNodeOnMessageCallback<T extends Record<string, unknown>, DB = unknown>(
   init: InitFn<T, DB>,
-  rest?: MessageHandleFn<DB>,
+  custom?: WorkerRequestHandler<DB>,
 ): void {
   if (!parentPort) {
     throw new Error('Must run in a worker thread')
   }
   parentPort.on(
     'message',
-    createGenericOnMessageCallback<T, DB>(init, (value) => parentPort!.postMessage(value), rest),
+    createGenericOnMessageCallback(init, (value) => parentPort!.postMessage(value), custom),
   )
 }
 
-/**
- * Util for handle node worker message in main thread
- */
-/**
- * Wire a Node.js `Worker` message event to the provided callback.
- */
-export const handleNodeWorker: HandleMessageFn<Worker> = (worker, cb) => worker.on('message', cb)
-
-/**
- * Util to create node mitt
- */
-/**
- * Create a Node.js-compatible event emitter for worker communication.
- */
-export function createNodeMitt(): IGenericEventEmitter {
-  return new NodeEventEmitterWrapper()
+export const handleNodeWorker: HandleWorkerFn<Worker> = (worker, handlers) => {
+  const onMessage = handlers.message
+  const onError = handlers.error
+  const onExit = (code: number): void =>
+    handlers.close(code === 0 ? undefined : new Error(`Worker exited with code ${code}`))
+  worker.on('message', onMessage)
+  worker.on('error', onError)
+  worker.on('exit', onExit)
+  return () => {
+    worker.off('message', onMessage)
+    worker.off('error', onError)
+    worker.off('exit', onExit)
+  }
 }
 
-/**
- * Configuration for {@link createNodeWorkerExecutor}.
- */
 export interface INodeWorkerDialectConfig<T extends Record<string, unknown>> extends Pick<
   IGenericSqliteWorkerExecutor<Worker, T>,
   'data'
@@ -67,33 +46,9 @@ export interface INodeWorkerDialectConfig<T extends Record<string, unknown>> ext
   worker: Worker | (() => Promisable<Worker>)
 }
 
-/**
- * Create worker executor for node
- * @param config {@link INodeWorkerDialectConfig}
- * @example
- * You can also manually create executor for node worker:
- * ```ts
- * import { GenericSqliteWorkerDialect } from 'kysely-generic-sqlite/worker'
- * import { handleNodeWorker, createNodeMitt } from 'kysely-generic-sqlite/worker-helper-node'
- *
- * const worker = new Worker('./worker.js')
- * const dialect = new GenericSqliteWorkerDialect(
- *   () => ({
- *     worker,
- *     mitt: createNodeMitt(),
- *     handle: handleNodeWorker,
- *   }),
- * )
- * ```
- */
 export function createNodeWorkerExecutor<T extends Record<string, unknown>>(
   config: INodeWorkerDialectConfig<T>,
 ): () => Promise<IGenericSqliteWorkerExecutor<Worker, T>> {
   const { worker, data } = config
-  return async () => ({
-    data,
-    worker: await access(worker),
-    handle: handleNodeWorker,
-    mitt: createNodeMitt(),
-  })
+  return async () => ({ data, worker: await access(worker), handle: handleNodeWorker })
 }

--- a/packages/dialect-generic-sqlite/src/worker/node-helper.ts
+++ b/packages/dialect-generic-sqlite/src/worker/node-helper.ts
@@ -78,10 +78,10 @@ export interface INodeWorkerDialectConfig<T extends Record<string, unknown>> ext
  *
  * const worker = new Worker('./worker.js')
  * const dialect = new GenericSqliteWorkerDialect(
- *   () => {
+ *   () => ({
  *     worker,
  *     mitt: createNodeMitt(),
- *     handle: handleWebWorker,
+ *     handle: handleNodeWorker,
  *   }),
  * )
  * ```

--- a/packages/dialect-generic-sqlite/src/worker/types.ts
+++ b/packages/dialect-generic-sqlite/src/worker/types.ts
@@ -8,6 +8,7 @@ export const closeEvent = '2'
 export const dataEvent = '3'
 export const endEvent = '4'
 export const cancelEvent = '5'
+export const cancelAckEvent = '6'
 
 export type InitMsg<T extends Record<string, unknown>> = [type: typeof initEvent, data: T]
 
@@ -38,17 +39,23 @@ export type MainToWorkerMsg<T extends Record<string, unknown>> =
   | StreamMsg
   | CancelMsg
 
-export type WorkerToMainMsg = {
-  [K in keyof Events]: [type: `${K}`, queryId: string | null, data: Events[K], err: unknown]
-}[keyof Events]
+export type WorkerToMainMsg<Row = unknown> = {
+  [K in keyof Events<Row>]: [
+    type: `${K}`,
+    queryId: string | null,
+    data: Events<Row>[K],
+    err: unknown,
+  ]
+}[keyof Events<Row>]
 
-type Events = {
+type Events<Row> = {
   0: null
   1: QueryResult<any> | null
   2: null
-  3: QueryResult<any>[] | null
+  3: Row | null
   4: null
   5: null
+  6: null
 }
 
 /** Minimal interface for a worker (web or Node.js). */

--- a/packages/dialect-generic-sqlite/src/worker/types.ts
+++ b/packages/dialect-generic-sqlite/src/worker/types.ts
@@ -2,138 +2,68 @@ import type { QueryResult } from 'kysely'
 
 import type { IGenericSqlite, Promisable } from '../type'
 
-export const initEvent = '0'
-export const runEvent = '1'
-export const closeEvent = '2'
-export const dataEvent = '3'
-export const endEvent = '4'
-export const cancelEvent = '5'
-export const cancelAckEvent = '6'
-
-export type InitMsg<T extends Record<string, unknown>> = [type: typeof initEvent, data: T]
-
-export type RunMsg = [
-  type: typeof runEvent,
-  queryId: string,
-  isSelect: boolean,
-  sql: string,
-  parameters: readonly unknown[],
-]
-
-export type StreamMsg = [
-  type: typeof dataEvent,
-  queryId: string,
-  isSelect: boolean,
-  sql: string,
-  parameters: readonly unknown[],
-  chunkSize?: number,
-]
-
-export type CloseMsg = [type: typeof closeEvent]
-export type CancelMsg = [type: typeof cancelEvent, queryId: string]
-
-export type MainToWorkerMsg<T extends Record<string, unknown>> =
-  | InitMsg<T>
-  | RunMsg
-  | CloseMsg
-  | StreamMsg
-  | CancelMsg
-
-export type WorkerToMainMsg<Row = unknown> = {
-  [K in keyof Events<Row>]: [
-    type: `${K}`,
-    queryId: string | null,
-    data: Events<Row>[K],
-    err: unknown,
-  ]
-}[keyof Events<Row>]
-
-type Events<Row> = {
-  0: null
-  1: QueryResult<any> | null
-  2: null
-  3: Row | null
-  4: null
-  5: null
-  6: null
-}
-
-/** Minimal interface for a worker (web or Node.js). */
 export interface IGenericWorker {
-  postMessage: (message: any) => void
-  terminate: () => void
+  postMessage: (message: unknown) => void
+  terminate: () => Promisable<unknown>
 }
 
-/**
- * Minimal event-emitter interface used to route messages between main thread
- * and worker.
- */
-export interface IGenericEventEmitter {
-  emit: (eventName: string, ...args: any[]) => void
-  on: (eventName: string, callback: (...value: any[]) => void) => void
-  once: (eventName: string, callback: (...value: any[]) => void) => void
-  /**
-   * Clear target or all listeners
-   * @param eventName optional event name
-   */
-  off: (eventName?: string) => void
+export interface WorkerHandlers {
+  message: (message: WorkerResponse) => void
+  error: (error: unknown) => void
+  close: (error?: unknown) => void
 }
 
-/**
- * Function that wires a worker's message event to a callback.
- */
-export type HandleMessageFn<T extends IGenericWorker> = (
+export type HandleWorkerFn<T extends IGenericWorker> = (
   worker: T,
-  cb: (msg: WorkerToMainMsg) => any,
-) => void
+  handlers: WorkerHandlers,
+) => () => void
 
-/**
- * Describes everything needed to bootstrap a worker-based SQLite executor.
- */
 export interface IGenericSqliteWorkerExecutor<
   W extends IGenericWorker,
   T extends Record<string, unknown>,
 > {
-  /**
-   * Extra data, as parameter in {@link InitFn}
-   */
   data?: T
-  /**
-   * Worker creator
-   */
   worker: W
-  /**
-   * Event emitter that used for dispatch messages from worker
-   */
-  mitt: IGenericEventEmitter
-  /**
-   * Convert data in worker message event callback and send to mitt
-   */
-  handle: HandleMessageFn<W>
+  handle: HandleWorkerFn<W>
 }
 
-/**
- * Initialize function for {@link createGenericOnMessageCallback}
- */
-/**
- * Callback that initializes a SQLite executor inside a worker.
- */
+export interface WorkerRequestHandler<DB = unknown> {
+  (executor: IGenericSqlite<DB>, request: { type: string; payload: unknown }): Promisable<unknown>
+}
+
 export type InitFn<T extends Record<string, unknown>, DB = unknown> = (
   data: T,
 ) => Promisable<IGenericSqlite<DB>>
 
-/**
- * Function that handle all message
- */
-/**
- * Optional callback for handling custom worker messages beyond the built-in
- * protocol.
- */
-export type MessageHandleFn<DB = unknown> = (
-  exec: IGenericSqlite<DB>,
-  type: string,
-  data1: unknown,
-  data2: unknown,
-  data3: unknown,
-  data4: unknown,
-) => Promisable<any>
+export type WorkerRequest<T extends Record<string, unknown> = Record<string, unknown>> =
+  | { type: 'init'; id: string; data: T }
+  | { type: 'execute'; id: string; isSelect: boolean; sql: string; parameters: readonly unknown[] }
+  | {
+      type: 'stream'
+      id: string
+      streamId: string
+      isSelect: boolean
+      sql: string
+      parameters: readonly unknown[]
+      chunkSize: number
+    }
+  | { type: 'pull'; id: string; streamId: string; chunkSize: number }
+  | { type: 'cancel'; id: string; target: 'query'; queryId: string }
+  | { type: 'cancel'; id: string; target: 'stream'; streamId: string }
+  | { type: 'close'; id: string }
+  | { type: 'custom'; id: string; name: string; payload: unknown }
+
+export type SerializedWorkerError = {
+  name: string
+  message: string
+  stack?: string
+}
+
+export type WorkerResponse =
+  | { type: 'ready'; id: string; canCancelQuery: boolean }
+  | { type: 'result'; id: string; result: QueryResult<unknown> }
+  | { type: 'stream'; id: string; rows: unknown[]; done: boolean }
+  | { type: 'cancelled'; id: string; error?: SerializedWorkerError }
+  | { type: 'closed'; id: string }
+  | { type: 'custom'; id: string; result: unknown }
+  | { type: 'error'; id: string; error: SerializedWorkerError }

--- a/packages/dialect-generic-sqlite/src/worker/utils.ts
+++ b/packages/dialect-generic-sqlite/src/worker/utils.ts
@@ -1,7 +1,15 @@
 import type { IGenericSqlite, Promisable } from '../type'
 
 import type { InitFn, MainToWorkerMsg, MessageHandleFn, WorkerToMainMsg } from './types'
-import { cancelEvent, closeEvent, dataEvent, endEvent, initEvent, runEvent } from './types'
+import {
+  cancelAckEvent,
+  cancelEvent,
+  closeEvent,
+  dataEvent,
+  endEvent,
+  initEvent,
+  runEvent,
+} from './types'
 
 /**
  * Create generic message handler
@@ -36,6 +44,7 @@ export function createGenericOnMessageCallback<T extends Record<string, unknown>
             [...activeStreams].map(async ([queryId, iterator]) => {
               canceledStreams.add(queryId)
               await iterator.return?.()
+              post([cancelAckEvent, queryId, null, null] satisfies WorkerToMainMsg)
             }),
           )
           await db.close()
@@ -46,6 +55,7 @@ export function createGenericOnMessageCallback<T extends Record<string, unknown>
           const queryId = data1
           canceledStreams.add(queryId)
           await activeStreams.get(queryId)?.return?.()
+          post([cancelAckEvent, queryId, null, null] satisfies WorkerToMainMsg)
           break
         }
 

--- a/packages/dialect-generic-sqlite/src/worker/utils.ts
+++ b/packages/dialect-generic-sqlite/src/worker/utils.ts
@@ -1,105 +1,168 @@
 import type { IGenericSqlite, Promisable } from '../type'
 
-import type { InitFn, MainToWorkerMsg, MessageHandleFn, WorkerToMainMsg } from './types'
-import {
-  cancelAckEvent,
-  cancelEvent,
-  closeEvent,
-  dataEvent,
-  endEvent,
-  initEvent,
-  runEvent,
+import type {
+  InitFn,
+  SerializedWorkerError,
+  WorkerRequest,
+  WorkerRequestHandler,
+  WorkerResponse,
 } from './types'
 
-/**
- * Create generic message handler
- * @param init Function that init sqlite executor
- * @param post Function that post message to main thread
- * @param message Handle custom messages. If returning data is not `undefined` and `null`, it will be set as second element of first param
- */
+export function serializeWorkerError(error: unknown): SerializedWorkerError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      ...(error.stack ? { stack: error.stack } : {}),
+    }
+  }
+  return { name: 'Error', message: String(error) }
+}
+
+export function deserializeWorkerError(error: SerializedWorkerError): Error {
+  const result = new Error(error.message)
+  result.name = error.name
+  if (error.stack) {
+    result.stack = error.stack
+  }
+  return result
+}
+
 export function createGenericOnMessageCallback<T extends Record<string, unknown>, DB = unknown>(
   init: InitFn<T, DB>,
-  post: (data: any) => void,
-  message?: MessageHandleFn<DB>,
-): (data: MainToWorkerMsg<T>) => Promise<void> {
-  let db: IGenericSqlite<DB>
-  const activeStreams = new Map<string, AsyncIterator<unknown> | Iterator<unknown>>()
-  const canceledStreams = new Set<string>()
-  return async ([type, data1, data2, data3, data4, data5]) => {
-    const ret: WorkerToMainMsg = [type, null, null, null]
-    let shouldPost = true
+  post: (data: WorkerResponse) => void,
+  custom?: WorkerRequestHandler<DB>,
+): (data: WorkerRequest<T>) => Promise<void> {
+  let db: IGenericSqlite<DB> | undefined
+  let closing = false
+  let queue = Promise.resolve()
+  const streams = new Map<string, AsyncIterator<unknown> | Iterator<unknown>>()
+
+  const send = (response: WorkerResponse): void => {
     try {
-      switch (type) {
-        case initEvent:
-          db = await init(data1)
-          break
-
-        case runEvent:
-          ret[1] = data1 // queryId
-          ret[2] = await db.query(data2, data3, data4)
-          break
-
-        case closeEvent:
-          await Promise.all(
-            [...activeStreams].map(async ([queryId, iterator]) => {
-              canceledStreams.add(queryId)
-              await iterator.return?.()
-              post([cancelAckEvent, queryId, null, null] satisfies WorkerToMainMsg)
-            }),
-          )
-          await db.close()
-          break
-
-        case cancelEvent: {
-          shouldPost = false
-          const queryId = data1
-          canceledStreams.add(queryId)
-          await activeStreams.get(queryId)?.return?.()
-          post([cancelAckEvent, queryId, null, null] satisfies WorkerToMainMsg)
-          break
-        }
-
-        case dataEvent: {
-          const queryId = data1
-          ret[1] = queryId
-          if (!db.iterator) {
-            throw new Error('streamQuery() is not supported.')
-          }
-          const it = db.iterator(data2, data3, data4, data5)
-          activeStreams.set(queryId, it)
-          try {
-            for await (const row of it) {
-              if (canceledStreams.has(queryId)) {
-                break
-              }
-              post([type, queryId, row as any, null] satisfies WorkerToMainMsg)
-            }
-          } finally {
-            activeStreams.delete(queryId)
-          }
-          if (canceledStreams.delete(queryId)) {
-            shouldPost = false
-          } else {
-            ret[0] = endEvent
-          }
-          break
-        }
-        default:
-          if (message) {
-            const data = await message(db, type, data1, data2, data3, data4)
-            if (data !== undefined && data !== null) {
-              ret[2] = data
-            }
-          } else {
-            throw new Error(`Unknown message type: ${type}`)
-          }
+      post(response)
+    } catch {
+      // There is no reliable recovery path if the transport cannot post a serializable response.
+    }
+  }
+  const enqueue = (task: () => Promise<void>): Promise<void> => {
+    const next = queue.then(task, task)
+    queue = next.catch(() => {})
+    return next
+  }
+  const cancel = async (id: string, streamId: string): Promise<void> => {
+    const iterator = streams.get(streamId)
+    streams.delete(streamId)
+    let error: SerializedWorkerError | undefined
+    try {
+      await iterator?.return?.()
+    } catch (cause) {
+      error = serializeWorkerError(cause)
+    }
+    send({ type: 'cancelled', id, ...(error ? { error } : {}) })
+  }
+  const pull = async (id: string, streamId: string, chunkSize: number): Promise<void> => {
+    const iterator = streams.get(streamId)
+    if (!iterator) {
+      throw new Error(`Unknown stream: ${streamId}`)
+    }
+    const rows: unknown[] = []
+    for (let index = 0; index < chunkSize; index++) {
+      const item = await iterator.next()
+      if (item.done) {
+        streams.delete(streamId)
+        send({ type: 'stream', id, rows, done: true })
+        return
       }
-    } catch (error) {
-      ret[3] = error
+      rows.push(item.value)
     }
-    if (shouldPost) {
-      post(ret)
+    send({ type: 'stream', id, rows, done: false })
+  }
+
+  return async (message) => {
+    if (message.type === 'cancel') {
+      if (message.target === 'query') {
+        let error: SerializedWorkerError | undefined
+        try {
+          await db?.cancelQuery?.()
+        } catch (cause) {
+          error = serializeWorkerError(cause)
+        }
+        send({ type: 'cancelled', id: message.id, ...(error ? { error } : {}) })
+      } else {
+        await cancel(message.id, message.streamId)
+      }
+      return
     }
+    await enqueue(async () => {
+      try {
+        if (closing && message.type !== 'close') {
+          throw new Error('Worker is closing')
+        }
+        switch (message.type) {
+          case 'init':
+            db = await init(message.data)
+            send({ type: 'ready', id: message.id, canCancelQuery: Boolean(db.cancelQuery) })
+            return
+          case 'execute':
+            if (!db) {
+              throw new Error('Worker is not initialized')
+            }
+            send({
+              type: 'result',
+              id: message.id,
+              result: await db.query(message.isSelect, message.sql, message.parameters),
+            })
+            return
+          case 'stream':
+            if (!db?.iterator) {
+              throw new Error('streamQuery() is not supported.')
+            }
+            if (!Number.isInteger(message.chunkSize) || message.chunkSize <= 0) {
+              throw new RangeError('chunkSize must be a positive integer')
+            }
+            streams.set(
+              message.streamId,
+              db.iterator(message.isSelect, message.sql, message.parameters),
+            )
+            await pull(message.id, message.streamId, message.chunkSize)
+            return
+          case 'pull':
+            if (!Number.isInteger(message.chunkSize) || message.chunkSize <= 0) {
+              throw new RangeError('chunkSize must be a positive integer')
+            }
+            await pull(message.id, message.streamId, message.chunkSize)
+            return
+          case 'close':
+            closing = true
+            await Promise.all(
+              [...streams.values()].map(async (iterator) => {
+                try {
+                  await iterator.return?.()
+                } catch {
+                  // Closing must continue even when an iterator cleanup fails.
+                }
+              }),
+            )
+            streams.clear()
+            await db?.close()
+            send({ type: 'closed', id: message.id })
+            return
+          case 'custom':
+            if (!db || !custom) {
+              throw new Error(`Unknown worker request: ${message.name}`)
+            }
+            send({
+              type: 'custom',
+              id: message.id,
+              result: await custom(db, { type: message.name, payload: message.payload }),
+            })
+            break
+        }
+      } catch (error) {
+        send({ type: 'error', id: message.id, error: serializeWorkerError(error) })
+      }
+    })
   }
 }
 

--- a/packages/dialect-generic-sqlite/src/worker/web-helper.ts
+++ b/packages/dialect-generic-sqlite/src/worker/web-helper.ts
@@ -51,7 +51,7 @@ export const handleWebWorker: HandleMessageFn<globalThis.Worker> = (worker, cb) 
  *
  * const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
  * const dialect = new GenericSqliteWorkerDialect(
- *   () => {
+ *   () => ({
  *     worker,
  *     mitt: mitt(),
  *     handle: handleWebWorker,

--- a/packages/dialect-generic-sqlite/src/worker/web-helper.ts
+++ b/packages/dialect-generic-sqlite/src/worker/web-helper.ts
@@ -1,71 +1,63 @@
 import type { Promisable } from '../type'
 
 import type {
-  HandleMessageFn,
+  HandleWorkerFn,
   IGenericSqliteWorkerExecutor,
   InitFn,
-  MessageHandleFn,
+  WorkerRequestHandler,
 } from './types'
 import { access, createGenericOnMessageCallback } from './utils'
 
-/**
- * Register the generic message callback on a web worker's `onmessage`.
- */
 export function createWebOnMessageCallback<T extends Record<string, unknown>, DB = unknown>(
   init: InitFn<T, DB>,
-  message?: MessageHandleFn<DB>,
+  custom?: WorkerRequestHandler<DB>,
 ): void {
-  const cb = createGenericOnMessageCallback<T, DB>(
+  const callback = createGenericOnMessageCallback(
     init,
     (value) => globalThis.postMessage(value),
-    message,
+    custom,
   )
-  globalThis.onmessage = ({ data }) => cb(data)
+  const onMessage = ({ data }: MessageEvent): void => void callback(data)
+  if ('addEventListener' in globalThis) {
+    globalThis.addEventListener('message', onMessage)
+  } else {
+    globalThis.onmessage = onMessage
+  }
 }
 
-/**
- * Configuration for {@link createWebWorkerExecutor}.
- */
+export const handleWebWorker: HandleWorkerFn<globalThis.Worker> = (worker, handlers) => {
+  const onMessage = ({ data }: MessageEvent): void => handlers.message(data)
+  const onError = (event: ErrorEvent): void =>
+    handlers.error(event.error ?? new Error(event.message))
+  const onMessageError = (): void =>
+    handlers.error(new Error('Worker message could not be deserialized'))
+  if (!('addEventListener' in worker)) {
+    const legacy = worker as unknown as { onmessage: ((event: MessageEvent) => void) | null }
+    legacy.onmessage = onMessage
+    return () => {
+      legacy.onmessage = null
+    }
+  }
+  worker.addEventListener('message', onMessage)
+  worker.addEventListener('error', onError)
+  worker.addEventListener('messageerror', onMessageError)
+  return () => {
+    worker.removeEventListener('message', onMessage)
+    worker.removeEventListener('error', onError)
+    worker.removeEventListener('messageerror', onMessageError)
+  }
+}
+
 export interface IWebWorkerDialectConfig<T extends Record<string, unknown>> extends Pick<
   IGenericSqliteWorkerExecutor<globalThis.Worker, T>,
-  'data' | 'mitt'
+  'data'
 > {
   worker: globalThis.Worker | (() => Promisable<globalThis.Worker>)
 }
 
-/**
- * Util for handle web worker message in main thread
- */
-export const handleWebWorker: HandleMessageFn<globalThis.Worker> = (worker, cb) =>
-  (worker.onmessage = ({ data }) => cb(data))
-
-/**
- * Create worker executor for web
- * @param config {@link IWebWorkerDialectConfig}
- * @example
- * You can also manually create executor for web worker:
- * ```ts
- * import { GenericSqliteWorkerDialect } from 'kysely-generic-sqlite/worker'
- * import { handleWebWorker } from 'kysely-generic-sqlite/worker-helper-web'
- * import { mitt } from 'zen-mitt'
- *
- * const worker = new Worker(new URL('./worker.js', import.meta.url), { type: 'module' })
- * const dialect = new GenericSqliteWorkerDialect(
- *   () => ({
- *     worker,
- *     mitt: mitt(),
- *     handle: handleWebWorker,
- *   }),
- * )
- * ```
- */
 export function createWebWorkerExecutor<T extends Record<string, unknown>>(
   config: IWebWorkerDialectConfig<T>,
 ): () => Promise<IGenericSqliteWorkerExecutor<globalThis.Worker, T>> {
   const { worker, ...rest } = config
-  return async () => ({
-    ...rest,
-    worker: await access(worker),
-    handle: handleWebWorker,
-  })
+  return async () => ({ ...rest, worker: await access(worker), handle: handleWebWorker })
 }

--- a/packages/dialect-generic-sqlite/test/index.test.ts
+++ b/packages/dialect-generic-sqlite/test/index.test.ts
@@ -7,6 +7,7 @@ import { buildQueryFn, GenericSqliteDialect, parseBigInt } from '../src'
 import { createGenericOnMessageCallback, GenericSqliteWorkerDialect } from '../src/worker'
 import type { IGenericEventEmitter } from '../src/worker'
 import {
+  cancelAckEvent,
   cancelEvent,
   closeEvent,
   dataEvent,
@@ -226,7 +227,37 @@ describe('generic sqlite dialect test', () => {
     await expect(driver.destroy()).resolves.toBeUndefined()
   })
 
-  it('rejects aborted worker queries and ignores late responses', async () => {
+  it('does not dispatch already-aborted worker queries', async () => {
+    const mitt = createTestMitt()
+    const messages: unknown[][] = []
+    const driver = new GenericSqliteWorkerDialect(() => ({
+      mitt,
+      worker: {
+        postMessage: (message) => {
+          const msg = message as unknown[]
+          messages.push(msg)
+          if (msg[0] === initEvent || msg[0] === closeEvent) {
+            mitt.emit(msg[0] as string, null, null, null)
+          }
+        },
+        terminate: () => {},
+      },
+      handle: () => {},
+    })).createDriver()
+
+    await driver.init()
+    const controller = new AbortController()
+    controller.abort()
+    const connection = await driver.acquireConnection()
+
+    await expect(
+      connection.executeQuery(CompiledQuery.raw('select 1'), { signal: controller.signal }),
+    ).rejects.toThrow('Query aborted')
+    expect(messages.some(([type]) => type === runEvent)).toBe(false)
+    await driver.destroy()
+  })
+
+  it('keeps dispatched worker queries pending after abort until worker responds', async () => {
     const mitt = createTestMitt()
     let capturedMessage: unknown[] | undefined
     const driver = new GenericSqliteWorkerDialect(() => ({
@@ -254,12 +285,20 @@ describe('generic sqlite dialect test', () => {
     })
 
     controller.abort()
-
-    await expect(promise).rejects.toThrow('Query aborted')
+    await Promise.resolve()
+    let settled = false
+    promise
+      .finally(() => {
+        settled = true
+      })
+      .catch(() => {})
+    await Promise.resolve()
+    expect(settled).toBe(false)
     expect(capturedMessage?.[0]).toBe(runEvent)
 
     mitt.emit(runEvent, capturedMessage?.[1], { rows: [{ id: 1 }] }, null)
 
+    await expect(promise).resolves.toStrictEqual({ rows: [{ id: 1 }] })
     await expect(driver.destroy()).resolves.toBeUndefined()
   })
 
@@ -290,12 +329,14 @@ describe('generic sqlite dialect test', () => {
       signal: controller.signal,
     })
     const next = stream.next()
+    await Promise.resolve()
     const streamMsg = messages.find(([type]) => type === dataEvent)
 
     controller.abort()
+    expect(messages).toContainEqual([cancelEvent, streamMsg?.[1]])
+    mitt.emit(cancelAckEvent, streamMsg?.[1], null, null)
 
     await expect(next).rejects.toThrow('Query aborted')
-    expect(messages).toContainEqual([cancelEvent, streamMsg?.[1]])
 
     await expect(driver.destroy()).resolves.toBeUndefined()
   })
@@ -350,6 +391,7 @@ describe('generic sqlite dialect test', () => {
     expect(messages).toStrictEqual([
       [initEvent, null, null, null],
       [dataEvent, 'stream-a', { id: 1 }, null],
+      [cancelAckEvent, 'stream-a', null, null],
     ])
     expect(messages.some(([type]) => type === endEvent)).toBe(false)
   })

--- a/packages/dialect-generic-sqlite/test/index.test.ts
+++ b/packages/dialect-generic-sqlite/test/index.test.ts
@@ -1,476 +1,159 @@
 import Database from 'better-sqlite3'
-import { CompiledQuery, Kysely } from 'kysely'
+import { CompiledQuery } from 'kysely'
 import { describe, expect, it } from 'vitest'
 
 import { testCase } from '../../test-utils'
 import { buildQueryFn, GenericSqliteDialect, parseBigInt } from '../src'
-import { createGenericOnMessageCallback, GenericSqliteWorkerDialect } from '../src/worker'
-import type { IGenericEventEmitter } from '../src/worker'
-import {
-  cancelAckEvent,
-  cancelEvent,
-  closeEvent,
-  dataEvent,
-  endEvent,
-  initEvent,
-  runEvent,
-} from '../src/worker/types'
+import { GenericSqliteWorkerDialect } from '../src/worker'
+import type { WorkerHandlers, WorkerResponse } from '../src/worker'
+import { createGenericOnMessageCallback } from '../src/worker/utils'
 
-describe('generic sqlite dialect test', () => {
-  it('better-sqlite3 executor', async () => {
+describe('generic sqlite dialect', () => {
+  it('executes better-sqlite3 queries', async () => {
     const db = new Database(':memory:')
-    const dialect = new GenericSqliteDialect(() => ({
-      db,
-      query: buildQueryFn({
-        all: (sql, parameters) => {
-          const stmt = db.prepare(sql)
-          if (stmt.reader) {
-            return stmt.all(parameters ?? [])
-          }
-          stmt.run(parameters ?? [])
-          return []
-        },
-        run: (sql, parameters) => {
-          const { changes, lastInsertRowid } = db.prepare(sql).run(parameters ?? [])
-          return {
-            numAffectedRows: parseBigInt(changes),
-            insertId: parseBigInt(lastInsertRowid),
-          }
-        },
-      }),
-      close: () => db.close(),
-    }))
-
-    await testCase(dialect, expect, false)
+    await testCase(
+      new GenericSqliteDialect(() => ({
+        db,
+        query: buildQueryFn({
+          all: (sql, parameters) => db.prepare(sql).all(parameters ?? []),
+          run: (sql, parameters) => {
+            const result = db.prepare(sql).run(parameters ?? [])
+            return {
+              insertId: parseBigInt(result.lastInsertRowid),
+              numAffectedRows: parseBigInt(result.changes),
+            }
+          },
+        }),
+        close: () => db.close(),
+      })),
+      expect,
+      false,
+    )
   })
-  it('does not request metadata for empty returning queries', async () => {
+
+  it('allows callers to classify ambiguous raw SQL', async () => {
     const calls: string[] = []
-    const dialect = new GenericSqliteDialect(() => ({
-      db: {},
-      query: buildQueryFn({
+    const query = buildQueryFn(
+      {
         all: (sql) => {
-          calls.push(sql)
+          calls.push(`all:${sql}`)
           return []
         },
         run: (sql) => {
-          calls.push(sql)
-          return {
-            insertId: 0n,
-            numAffectedRows: 0n,
-          }
+          calls.push(`run:${sql}`)
+          return { insertId: 1n, numAffectedRows: 1n }
         },
-      }),
+      },
+      { classifyQuery: ({ sql }) => (sql.startsWith('with') ? 'write' : undefined) },
+    )
+    await query(false, 'with x(v) as (select 1) insert into test(v) select v from x', [])
+    expect(calls[0]).toMatch(/^run:/)
+  })
+
+  it('pulls worker rows in batches without buffering the whole stream', async () => {
+    const { dialect } = createInMemoryWorkerDialect(async () => ({
+      db: {},
       close: () => {},
-    }))
-    const db = new Kysely<{ test: { age: number; id: number } }>({ dialect })
-
-    try {
-      await db.updateTable('test').set({ age: 1 }).where('id', '=', -1).returningAll().execute()
-    } finally {
-      await db.destroy()
-    }
-
-    expect(calls).toHaveLength(1)
-    expect(calls[0]).toContain('returning')
-  })
-  it('ignores returning inside raw SQL literals', async () => {
-    const calls: string[] = []
-    const query = buildQueryFn({
-      all: (sql) => {
-        calls.push(sql)
-        return []
+      query: () => ({ rows: [] }),
+      *iterator() {
+        yield { id: 1 }
+        yield { id: 2 }
+        yield { id: 3 }
       },
-      run: (sql) => {
-        calls.push(sql)
-        return {
-          insertId: 1n,
-          numAffectedRows: 1n,
-        }
-      },
-    })
-
-    const result = await query(false, "insert into test(name) values ('returning')", [], {} as any)
-
-    expect(result).toStrictEqual({
-      insertId: 1n,
-      numAffectedRows: 1n,
-      rows: [],
-    })
-    expect(calls).toStrictEqual(["insert into test(name) values ('returning')"])
-  })
-  it('keeps worker query responses isolated by query id', async () => {
-    const messages: unknown[] = []
-    const onMessage = createGenericOnMessageCallback(
-      async () => ({
-        db: {},
-        close: () => {},
-        query: async (_isSelect, _sql, parameters) => ({
-          rows: [{ id: parameters?.[0] }],
-        }),
-        *iterator(_isSelect, _sql, parameters, chunkSize) {
-          yield {
-            chunkSize,
-            id: parameters?.[0],
-          }
-        },
-      }),
-      (message) => messages.push(message),
-    )
-
-    await onMessage([initEvent, {}])
-    await onMessage([runEvent, 'query-a', true, 'select ?', ['a']])
-    await onMessage([runEvent, 'query-b', true, 'select ?', ['b']])
-    await onMessage([dataEvent, 'stream-a', true, 'select ?', ['a'], 2])
-
-    expect(messages).toStrictEqual([
-      [initEvent, null, null, null],
-      [runEvent, 'query-a', { rows: [{ id: 'a' }] }, null],
-      [runEvent, 'query-b', { rows: [{ id: 'b' }] }, null],
-      [dataEvent, 'stream-a', { chunkSize: 2, id: 'a' }, null],
-      ['4', 'stream-a', null, null],
-    ])
-  })
-
-  it('rejects worker streams when iterator is unsupported', async () => {
-    const mitt = createTestMitt()
-    const onMessage = createGenericOnMessageCallback(
-      async () => ({
-        db: {},
-        close: () => {},
-        query: () => ({ rows: [] }),
-      }),
-      (message) => {
-        const [type, ...args] = message as [string, ...unknown[]]
-        mitt.emit(type, ...args)
-      },
-    )
-
-    const dialect = new GenericSqliteWorkerDialect(() => ({
-      mitt,
-      worker: {
-        postMessage: (message) => void onMessage(message as never),
-        terminate: () => {},
-      },
-      handle: () => {},
     }))
     const driver = dialect.createDriver()
     await driver.init()
+    const connection = await driver.acquireConnection()
+    const batches: unknown[][] = []
+    for await (const result of connection.streamQuery(CompiledQuery.raw('select 1'), 2)) {
+      batches.push(result.rows)
+    }
+    expect(batches).toStrictEqual([[{ id: 1 }, { id: 2 }], [{ id: 3 }]])
+    await driver.destroy()
+  })
 
+  it('acknowledges cancellation even when iterator cleanup fails', async () => {
+    const { dialect } = createInMemoryWorkerDialect(async () => ({
+      db: {},
+      close: () => {},
+      query: () => ({ rows: [] }),
+      iterator: () => ({
+        next: async () => ({ done: false, value: { id: 1 } }),
+        return: async () => {
+          throw new Error('cleanup failed')
+        },
+        [Symbol.iterator]() {
+          return this
+        },
+      }),
+    }))
+    const driver = dialect.createDriver()
+    await driver.init()
     const connection = await driver.acquireConnection()
     const stream = connection.streamQuery(CompiledQuery.raw('select 1'), 1)
-
-    await expect(stream.next()).rejects.toThrow('streamQuery() is not supported.')
-
-    // await driver.releaseConnection(connection)
+    await stream.next()
+    await expect(stream.return!()).resolves.toMatchObject({ done: true })
     await driver.destroy()
   })
 
-  it('rejects worker streams when iterator throws', async () => {
-    const mitt = createTestMitt()
-    const onMessage = createGenericOnMessageCallback(
-      async () => ({
-        db: {},
-        close: () => {},
-        query: () => ({ rows: [] }),
-        *iterator() {
-          yield { id: 1 }
-          throw new Error('iterator failed')
-        },
-      }),
-      (message) => {
-        const [type, ...args] = message as [string, ...unknown[]]
-        mitt.emit(type, ...args)
+  it('waits for an active query before closing the worker database', async () => {
+    let finish: (() => void) | undefined
+    const events: string[] = []
+    const { dialect } = createInMemoryWorkerDialect(async () => ({
+      db: {},
+      query: async () => {
+        events.push('query')
+        await new Promise<void>((resolve) => {
+          finish = resolve
+        })
+        return { rows: [] }
       },
-    )
-
-    const dialect = new GenericSqliteWorkerDialect(() => ({
-      mitt,
-      worker: {
-        postMessage: (message) => void onMessage(message as never),
-        terminate: () => {},
-      },
-      handle: () => {},
+      close: () => events.push('close'),
     }))
     const driver = dialect.createDriver()
     await driver.init()
-
     const connection = await driver.acquireConnection()
-    const stream = connection.streamQuery(CompiledQuery.raw('select 1'), 1)
-
-    await expect(stream.next()).resolves.toStrictEqual({
-      done: false,
-      value: { rows: [{ id: 1 }] },
-    })
-    await expect(stream.next()).rejects.toThrow('iterator failed')
-
-    // await driver.releaseConnection(connection)
-    await driver.destroy()
-  })
-
-  it('resolves init and destroy with synchronous worker acknowledgements', async () => {
-    const mitt = createTestMitt()
-    const driver = new GenericSqliteWorkerDialect(() => ({
-      mitt,
-      worker: {
-        postMessage: (message) => {
-          const [type] = message as [string]
-          if (type === initEvent || type === closeEvent) {
-            mitt.emit(type, null, null, null)
-          }
-        },
-        terminate: () => {},
-      },
-      handle: () => {},
-    })).createDriver()
-
-    await expect(driver.init()).resolves.toBeUndefined()
-    await expect(driver.destroy()).resolves.toBeUndefined()
-  })
-
-  it('does not dispatch already-aborted worker queries', async () => {
-    const mitt = createTestMitt()
-    const messages: unknown[][] = []
-    const driver = new GenericSqliteWorkerDialect(() => ({
-      mitt,
-      worker: {
-        postMessage: (message) => {
-          const msg = message as unknown[]
-          messages.push(msg)
-          if (msg[0] === initEvent || msg[0] === closeEvent) {
-            mitt.emit(msg[0] as string, null, null, null)
-          }
-        },
-        terminate: () => {},
-      },
-      handle: () => {},
-    })).createDriver()
-
-    await driver.init()
-    const controller = new AbortController()
-    controller.abort()
-    const connection = await driver.acquireConnection()
-
-    await expect(
-      connection.executeQuery(CompiledQuery.raw('select 1'), { signal: controller.signal }),
-    ).rejects.toThrow('Query aborted')
-    expect(messages.some(([type]) => type === runEvent)).toBe(false)
-    await driver.destroy()
-  })
-
-  it('keeps dispatched worker queries pending after abort until worker responds', async () => {
-    const mitt = createTestMitt()
-    let capturedMessage: unknown[] | undefined
-    const driver = new GenericSqliteWorkerDialect(() => ({
-      mitt,
-      worker: {
-        postMessage: (message) => {
-          const [type] = message as [string]
-          if (type === initEvent || type === closeEvent) {
-            mitt.emit(type, null, null, null)
-            return
-          }
-          capturedMessage = message as unknown[]
-        },
-        terminate: () => {},
-      },
-      handle: () => {},
-    })).createDriver()
-
-    await driver.init()
-
-    const controller = new AbortController()
-    const connection = await driver.acquireConnection()
-    const promise = connection.executeQuery(CompiledQuery.raw('select 1'), {
-      signal: controller.signal,
-    })
-
-    controller.abort()
+    const running = connection.executeQuery(CompiledQuery.raw('select 1'))
     await Promise.resolve()
-    let settled = false
-    promise
-      .finally(() => {
-        settled = true
-      })
-      .catch(() => {})
+    const destroying = driver.destroy()
     await Promise.resolve()
-    expect(settled).toBe(false)
-    expect(capturedMessage?.[0]).toBe(runEvent)
-
-    mitt.emit(runEvent, capturedMessage?.[1], { rows: [{ id: 1 }] }, null)
-
-    await expect(promise).resolves.toStrictEqual({ rows: [{ id: 1 }] })
-    await expect(driver.destroy()).resolves.toBeUndefined()
+    expect(events).toStrictEqual(['query'])
+    finish?.()
+    await running
+    await destroying
+    expect(events).toStrictEqual(['query', 'close'])
   })
 
-  it('sends worker stream cancellation when aborted', async () => {
-    const mitt = createTestMitt()
-    const messages: unknown[][] = []
-    const driver = new GenericSqliteWorkerDialect(() => ({
-      mitt,
-      worker: {
-        postMessage: (message) => {
-          const msg = message as unknown[]
-          messages.push(msg)
-          const [type] = msg as [string]
-          if (type === initEvent || type === closeEvent) {
-            mitt.emit(type, null, null, null)
-          }
-        },
-        terminate: () => {},
-      },
-      handle: () => {},
-    })).createDriver()
-
-    await driver.init()
-
-    const controller = new AbortController()
-    const connection = await driver.acquireConnection()
-    const stream = connection.streamQuery(CompiledQuery.raw('select 1'), 1, {
-      signal: controller.signal,
-    })
-    const next = stream.next()
-    await Promise.resolve()
-    const streamMsg = messages.find(([type]) => type === dataEvent)
-
-    controller.abort()
-    expect(messages).toContainEqual([cancelEvent, streamMsg?.[1]])
-    mitt.emit(cancelAckEvent, streamMsg?.[1], null, null)
-
-    await expect(next).rejects.toThrow('Query aborted')
-
-    await expect(driver.destroy()).resolves.toBeUndefined()
-  })
-
-  it('returns active worker stream iterators when cancelled', async () => {
-    const messages: unknown[][] = []
-    let resolveNext: ((value: IteratorResult<unknown>) => void) | undefined
-    let returned = false
-
-    const iterator: AsyncIterableIterator<unknown> = {
-      [Symbol.asyncIterator]() {
-        return this
-      },
-      next: (() => {
-        let first = true
-        return () => {
-          if (first) {
-            first = false
-            return Promise.resolve({ done: false, value: { id: 1 } })
-          }
-          return new Promise<IteratorResult<unknown>>((resolve) => {
-            resolveNext = resolve
-          })
-        }
-      })(),
-      return: () => {
-        returned = true
-        resolveNext?.({ done: true, value: undefined })
-        return Promise.resolve({ done: true, value: undefined })
-      },
-      throw: (error?: unknown) => Promise.reject(error),
-    }
-
-    const onMessage = createGenericOnMessageCallback(
-      async () => ({
-        db: {},
-        close: () => {},
-        query: () => ({ rows: [] }),
-        iterator: () => iterator,
-      }),
-      (message) => messages.push(message as unknown[]),
-    )
-
-    await onMessage([initEvent, {}])
-    const stream = onMessage([dataEvent, 'stream-a', true, 'select 1', [], 1])
-    await Promise.resolve()
-
-    await onMessage([cancelEvent, 'stream-a'])
-    await stream
-
-    expect(returned).toBe(true)
-    expect(messages).toStrictEqual([
-      [initEvent, null, null, null],
-      [dataEvent, 'stream-a', { id: 1 }, null],
-      [cancelAckEvent, 'stream-a', null, null],
-    ])
-    expect(messages.some(([type]) => type === endEvent)).toBe(false)
-  })
-
-  it('buffers synchronous worker stream rows without dropping data', async () => {
-    const mitt = createTestMitt()
-    const messages: unknown[] = []
-    const onMessage = createGenericOnMessageCallback(
-      async () => ({
-        db: {},
-        close: () => {},
-        query: () => ({ rows: [] }),
-        *iterator() {
-          yield { id: 1 }
-          yield { id: 2 }
-          yield { id: 3 }
-        },
-      }),
-      (message) => {
-        messages.push(message)
-        const [type, ...args] = message as [string, ...unknown[]]
-        mitt.emit(type, ...args)
-      },
-    )
-
+  it('rejects pending operations when the worker fails', async () => {
+    let handlers: WorkerHandlers | undefined
     const dialect = new GenericSqliteWorkerDialect(() => ({
-      mitt,
-      worker: {
-        postMessage: (message) => void onMessage(message as never),
-        terminate: () => {},
+      worker: { postMessage: () => {}, terminate: () => {} },
+      handle: (_worker, value) => {
+        handlers = value
+        return () => {}
       },
-      handle: () => {},
     }))
     const driver = dialect.createDriver()
-    await driver.init()
-
-    const connection = await driver.acquireConnection()
-    const query = CompiledQuery.raw('select 1')
-    const rows: unknown[] = []
-    for await (const result of connection.streamQuery(query, 1)) {
-      rows.push(...result.rows)
-    }
-    // await driver.releaseConnection(connection)
-    await driver.destroy()
-
-    expect(rows).toStrictEqual([{ id: 1 }, { id: 2 }, { id: 3 }])
-    expect(messages).toHaveLength(6)
+    const init = driver.init()
+    await Promise.resolve()
+    handlers?.error(new Error('worker crashed'))
+    await expect(init).rejects.toThrow('worker crashed')
   })
 })
 
-function createTestMitt(): IGenericEventEmitter {
-  const listeners = new Map<string, Set<(...value: any[]) => void>>()
-
-  return {
-    emit: (eventName: string, ...args: any[]) => {
-      for (const listener of listeners.get(eventName) ?? []) {
-        listener(...args)
-      }
+function createInMemoryWorkerDialect(init: () => any): {
+  dialect: GenericSqliteWorkerDialect<any, Record<string, unknown>>
+} {
+  let handlers: WorkerHandlers | undefined
+  const post = createGenericOnMessageCallback(init, (response: WorkerResponse) =>
+    handlers?.message(response),
+  )
+  const dialect = new GenericSqliteWorkerDialect(() => ({
+    worker: { postMessage: (message) => void post(message as any), terminate: () => {} },
+    handle: (_worker, value) => {
+      handlers = value
+      return () => {}
     },
-    on: (eventName: string, callback: (...value: any[]) => void) => {
-      const eventListeners = listeners.get(eventName) ?? new Set()
-      eventListeners.add(callback)
-      listeners.set(eventName, eventListeners)
-    },
-    once: (eventName: string, callback: (...value: any[]) => void) => {
-      const onceCallback = (...value: any[]): void => {
-        listeners.get(eventName)?.delete(onceCallback)
-        callback(...value)
-      }
-      const eventListeners = listeners.get(eventName) ?? new Set()
-      eventListeners.add(onceCallback)
-      listeners.set(eventName, eventListeners)
-    },
-    off: (eventName?: string): void => {
-      if (eventName) {
-        listeners.delete(eventName)
-      } else {
-        listeners.clear()
-      }
-    },
-  }
+  }))
+  return { dialect }
 }

--- a/packages/dialect-sqlite-worker/package.json
+++ b/packages/dialect-sqlite-worker/package.json
@@ -30,7 +30,7 @@
   "typesVersions": {
     "*": {
       "worker": [
-        "./dist/worker.d.ts"
+        "./dist/worker.d.mts"
       ]
     }
   },

--- a/packages/dialect-sqlite-worker/src/index.ts
+++ b/packages/dialect-sqlite-worker/src/index.ts
@@ -5,7 +5,7 @@ import type { Options } from 'better-sqlite3'
 import { access } from 'kysely-generic-sqlite'
 import type { IBaseSqliteDialectConfig, Promisable } from 'kysely-generic-sqlite'
 import { GenericSqliteWorkerDialect } from 'kysely-generic-sqlite/worker'
-import { createNodeMitt, handleNodeWorker } from 'kysely-generic-sqlite/worker-helper-node'
+import { handleNodeWorker } from 'kysely-generic-sqlite/worker-helper-node'
 
 export * from './worker/utils'
 
@@ -53,7 +53,6 @@ export class SqliteWorkerDialect extends GenericSqliteWorkerDialect<Worker, {}> 
       })
       return {
         handle: handleNodeWorker,
-        mitt: createNodeMitt(),
         worker,
       }
     }, onCreateConnection)

--- a/packages/dialect-sqlite-worker/src/worker/utils.ts
+++ b/packages/dialect-sqlite-worker/src/worker/utils.ts
@@ -4,7 +4,7 @@ import type BetterSqlite3 from 'better-sqlite3'
 import Database from 'better-sqlite3'
 import type { IGenericSqlite, Promisable } from 'kysely-generic-sqlite'
 import { parseBigInt } from 'kysely-generic-sqlite'
-import type { MessageHandleFn } from 'kysely-generic-sqlite/worker'
+import type { WorkerRequestHandler } from 'kysely-generic-sqlite/worker'
 import { createNodeOnMessageCallback } from 'kysely-generic-sqlite/worker-helper-node'
 
 /**
@@ -47,13 +47,13 @@ export const defaultCreateDatabaseFn: CreateDatabaseFn = (fileName, options) =>
  */
 export function createOnMessageCallback(
   create: CreateDatabaseFn,
-  message?: MessageHandleFn<BetterSqlite3.Database>,
+  custom?: WorkerRequestHandler<BetterSqlite3.Database>,
 ): void {
   const { src, option } = workerData
   createNodeOnMessageCallback<{}, BetterSqlite3.Database>(async () => {
     const db = await create(src, option)
     return createSqliteExecutor(db)
-  }, message)
+  }, custom)
 }
 
 /**

--- a/packages/dialect-wasqlite-worker/package.json
+++ b/packages/dialect-wasqlite-worker/package.json
@@ -38,8 +38,7 @@
     "build": "tsdown"
   },
   "dependencies": {
-    "kysely-generic-sqlite": "workspace:*",
-    "zen-mitt": "^3.1.0"
+    "kysely-generic-sqlite": "workspace:*"
   },
   "devDependencies": {
     "@subframe7536/sqlite-wasm": "catalog:",

--- a/packages/dialect-wasqlite-worker/src/index.ts
+++ b/packages/dialect-wasqlite-worker/src/index.ts
@@ -1,7 +1,6 @@
 import { isModuleWorkerSupport, isOpfsSupported } from '@subframe7536/sqlite-wasm'
 import { GenericSqliteWorkerDialect } from 'kysely-generic-sqlite/worker'
 import { handleWebWorker } from 'kysely-generic-sqlite/worker-helper-web'
-import { mitt } from 'zen-mitt'
 
 import type { InitData, WaSqliteWorkerDialectConfig } from './type'
 
@@ -20,12 +19,10 @@ export class WaSqliteWorkerDialect extends GenericSqliteWorkerDialect<globalThis
    * @param config - {@link WaSqliteWorkerDialectConfig}
    */
   constructor(config: WaSqliteWorkerDialectConfig) {
-    const { onCreateConnection, worker, fileName, preferOPFS, url, message } = config
+    const { onCreateConnection, worker, fileName, preferOPFS, url } = config
     super(async () => {
       const supportModule = isModuleWorkerSupport()
       const useOPFS = preferOPFS ? await isOpfsSupported() : false
-      const m = mitt()
-      await message?.(m)
       return {
         data: {
           fileName,
@@ -39,7 +36,6 @@ export class WaSqliteWorkerDialect extends GenericSqliteWorkerDialect<globalThis
           : supportModule
             ? new Worker(new URL('worker.js', import.meta.url), { type: 'module' })
             : new Worker(new URL('worker.js', import.meta.url)),
-        mitt: m,
         handle: handleWebWorker,
       }
     }, onCreateConnection)

--- a/packages/dialect-wasqlite-worker/src/type.ts
+++ b/packages/dialect-wasqlite-worker/src/type.ts
@@ -1,5 +1,4 @@
-import type { IBaseSqliteDialectConfig, Promisable } from 'kysely-generic-sqlite'
-import type { IGenericEventEmitter } from 'kysely-generic-sqlite/worker'
+import type { IBaseSqliteDialectConfig } from 'kysely-generic-sqlite'
 
 export interface WaSqliteWorkerDialectConfig extends IBaseSqliteDialectConfig {
   /**
@@ -39,11 +38,6 @@ export interface WaSqliteWorkerDialectConfig extends IBaseSqliteDialectConfig {
    *   : new URL(`@subframe7536/sqlite-wasm/dist/wa-sqlite.wasm`, import.meta.url).href
    */
   url?: string | ((useAsyncWasm: boolean) => string)
-  /**
-   * Handle custom messages for event emitter
-   * @param mitt event emitter
-   */
-  message?: (mitt: IGenericEventEmitter) => Promisable<void>
 }
 
 /**

--- a/packages/dialect-wasqlite-worker/src/worker/utils.ts
+++ b/packages/dialect-wasqlite-worker/src/worker/utils.ts
@@ -8,7 +8,7 @@ import {
 import { SQLITE_ROW, SQLITE_DONE } from '@subframe7536/sqlite-wasm/constant'
 import { parseBigInt } from 'kysely-generic-sqlite'
 import type { IGenericSqlite, Promisable } from 'kysely-generic-sqlite'
-import type { MessageHandleFn } from 'kysely-generic-sqlite/worker'
+import type { WorkerRequestHandler } from 'kysely-generic-sqlite/worker'
 import { createWebOnMessageCallback } from 'kysely-generic-sqlite/worker-helper-web'
 
 import type { InitData } from '../type'
@@ -99,12 +99,12 @@ async function prepareStatement(
  */
 export function createOnMessageCallback(
   create: CreateDatabaseFn,
-  message?: MessageHandleFn<SQLiteDBCore>,
+  custom?: WorkerRequestHandler<SQLiteDBCore>,
 ): void {
   createWebOnMessageCallback<InitData, SQLiteDBCore>(async (initData) => {
     const core = await create(initData!)
     return createSqliteExecutor(core)
-  }, message)
+  }, custom)
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,9 +132,6 @@ importers:
       kysely-generic-sqlite:
         specifier: workspace:*
         version: link:../dialect-generic-sqlite
-      zen-mitt:
-        specifier: ^3.1.0
-        version: 3.1.0
     devDependencies:
       '@subframe7536/sqlite-wasm':
         specifier: 'catalog:'
@@ -1474,9 +1471,6 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  zen-mitt@3.1.0:
-    resolution: {integrity: sha512-I0KUcnQb9rnx1/Cu9xtlJPj2e2r+yb3putg2Tjx9mjY2pVTnAzH4N/KwnIpnG+RQCz3VPj33NftGis4ug5s/2g==}
-
 snapshots:
 
   '@babel/code-frame@7.29.7':
@@ -2559,5 +2553,3 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.9.0: {}
-
-  zen-mitt@3.1.0: {}

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { dirname, join } from 'node:path'
+
+const root = process.cwd()
+const packages = [
+  'packages/dialect-generic-sqlite',
+  'packages/dialect-sqlite-worker',
+  'packages/dialect-bun-worker',
+  'packages/dialect-wasm',
+  'packages/dialect-tauri',
+  'packages/dialect-wasqlite-worker',
+]
+const require = createRequire(import.meta.url)
+
+for (const packageDir of packages) {
+  const pkgPath = join(root, packageDir, 'package.json')
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'))
+  const base = dirname(pkgPath)
+  const checkPath = (field, value) => {
+    if (typeof value === 'string' && value.startsWith('./') && !existsSync(join(base, value))) {
+      throw new Error(`${pkg.name} ${field} points to missing ${value}`)
+    }
+  }
+  checkPath('main', pkg.main)
+  checkPath('module', pkg.module)
+  checkPath('types', pkg.types)
+  for (const [key, target] of Object.entries(pkg.exports ?? {})) {
+    if (typeof target === 'string') {
+      checkPath(`exports[${key}]`, target)
+    } else {
+      for (const [condition, value] of Object.entries(target)) {
+        checkPath(`exports[${key}].${condition}`, value)
+      }
+    }
+  }
+  for (const [key, values] of Object.entries(pkg.typesVersions?.['*'] ?? {})) {
+    for (const value of values) {
+      checkPath(`typesVersions.${key}`, value)
+    }
+  }
+  for (const [dep, range] of Object.entries(pkg.dependencies ?? {})) {
+    if (range.startsWith('workspace:')) {
+      const workspace = packages
+        .map((p) => JSON.parse(readFileSync(join(root, p, 'package.json'), 'utf8')))
+        .find((p) => p.name === dep)
+      if (!workspace) {
+        throw new Error(`${pkg.name} has unresolved workspace dependency ${dep}`)
+      }
+      if (!workspace.version) {
+        throw new Error(`${dep} has no publishable version`)
+      }
+    }
+  }
+  const runtimeRequiresSpecialHost = pkg.name.includes('bun')
+  if (!runtimeRequiresSpecialHost) {
+    const rootExport = pkg.exports?.['.']
+    const rootImport =
+      typeof rootExport === 'string' ? rootExport : (rootExport?.import ?? pkg.module ?? pkg.main)
+    await import(join(base, rootImport))
+  }
+  if (!runtimeRequiresSpecialHost && pkg.exports?.['.']?.require) {
+    require(join(base, pkg.exports['.'].require))
+  }
+  for (const [key, target] of Object.entries(pkg.exports ?? {})) {
+    if (key === '.' || key === './package.json') {
+      continue
+    }
+    if (key.includes('worker')) {
+      continue
+    }
+    if (runtimeRequiresSpecialHost) {
+      continue
+    }
+    if (typeof target === 'object') {
+      if (target.import) {
+        await import(join(base, target.import))
+      }
+      if (target.require) {
+        require(join(base, target.require))
+      }
+    } else {
+      await import(join(base, target))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Replace the v2-beta generic SQLite worker protocol with a request-id based RPC transport.

## Key changes

- Replace numeric tuple events, `mitt`, and `MessageHandleFn` with tagged `WorkerRequest` / `WorkerResponse` messages and `WorkerRequestHandler`.
- Add `GenericSqliteWorkerConnection.request()` for custom worker RPC.
- Make streaming pull-based and batch-oriented: only one batch is in flight, avoiding unbounded row buffering and per-row IPC.
- Add worker lifecycle handling for message errors, process errors, exits, synchronous post failures, init failures, and idempotent cleanup.
- Serialize database work and make shutdown wait for accepted work, preventing close/query races and leaked workers.
- Add optional `IGenericSqlite.cancelQuery()` support for Kysely's native `cancel query` abort strategy.
- Add `classifyQuery` options to `buildQueryFn` and `buildQueryFnAlt`; Kysely DML AST takes precedence, while PRAGMA/WITH/raw SQL limitations are documented.
- Migrate Node, Web, Bun, better-sqlite3, and wa-sqlite worker integrations; remove the unused `zen-mitt` dependency.

## Breaking changes

This is an intentional v2-beta protocol break:

- Numeric worker events and tuple message types are removed.
- `IGenericEventEmitter`, `mitt`, and `MessageHandleFn` are removed.
- Custom worker extensions must use `WorkerRequestHandler` and `GenericSqliteWorkerConnection.request()`.

## Verification

- `pnpm build`
- `pnpm test` — 14 tests passed
- `pnpm test:bun`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm smoke:packages`