### PR TITLE
fix(kysely-bun-worker): support CJS normal dialect

### DIFF
--- a/packages/dialect-bun-worker/package.json
+++ b/packages/dialect-bun-worker/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test": "tsdown && bun test",
     "test:dev": "tsdown && bun test",
     "build": "tsdown"
   },

--- a/packages/dialect-bun-worker/src/executor.ts
+++ b/packages/dialect-bun-worker/src/executor.ts
@@ -1,5 +1,5 @@
 import type { Statement } from 'bun:sqlite'
-import type Database from 'bun:sqlite'
+import type { Database } from 'bun:sqlite'
 
 import type { IGenericSqlite } from 'kysely-generic-sqlite'
 import { parseBigInt } from 'kysely-generic-sqlite'

--- a/packages/dialect-bun-worker/src/main.ts
+++ b/packages/dialect-bun-worker/src/main.ts
@@ -1,4 +1,4 @@
-import Database from 'bun:sqlite'
+import { Database } from 'bun:sqlite'
 
 import { GenericSqliteDialect } from 'kysely-generic-sqlite'
 

--- a/packages/dialect-bun-worker/src/type.ts
+++ b/packages/dialect-bun-worker/src/type.ts
@@ -1,4 +1,4 @@
-import type Database from 'bun:sqlite'
+import type { Database } from 'bun:sqlite'
 
 import type { IBaseSqliteDialectConfig } from 'kysely-generic-sqlite'
 

--- a/packages/dialect-bun-worker/src/worker/utils.ts
+++ b/packages/dialect-bun-worker/src/worker/utils.ts
@@ -1,4 +1,4 @@
-import Database from 'bun:sqlite'
+import { Database } from 'bun:sqlite'
 
 import type { Promisable } from 'kysely-generic-sqlite'
 import type { WorkerRequestHandler } from 'kysely-generic-sqlite/worker'

--- a/packages/dialect-bun-worker/test/package.test.ts
+++ b/packages/dialect-bun-worker/test/package.test.ts
@@ -1,20 +1,55 @@
 import { describe, expect, it } from 'bun:test'
-import { createRequire } from 'node:module'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-import { Kysely, sql } from 'kysely'
-
-const require = createRequire(import.meta.url)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 
 describe('bun sqlite package', () => {
-  it('executes a query through the CommonJS normal entry point', async () => {
-    const { BunSqliteDialect } = require('../dist/normal.cjs')
-    const db = new Kysely({ dialect: new BunSqliteDialect({ url: ':memory:' }) })
+  it('executes a query through the CommonJS normal entry point', () => {
+    const projectDir = mkdtempSync(join(tmpdir(), 'kysely-bun-worker-cjs-'))
 
     try {
-      const result = await sql<{ value: number }>`select 1 as value`.execute(db)
-      expect(result.rows).toEqual([{ value: 1 }])
+      createCommonJsProject(projectDir)
+      const result = Bun.spawnSync(['bun', 'run', 'index.js'], {
+        cwd: projectDir,
+        stderr: 'pipe',
+        stdout: 'pipe',
+      })
+
+      const output = new TextDecoder().decode(result.stderr)
+      expect(result.exitCode, output).toBe(0)
     } finally {
-      await db.destroy()
+      rmSync(projectDir, { force: true, recursive: true })
     }
   })
 })
+
+function createCommonJsProject(projectDir: string): void {
+  const nodeModulesDir = join(projectDir, 'node_modules')
+  mkdirSync(nodeModulesDir)
+  writeFileSync(join(projectDir, 'package.json'), '{"type":"commonjs"}')
+  writeFileSync(
+    join(projectDir, 'index.js'),
+    [
+      "const { Kysely, sql } = require('kysely')",
+      "const { BunSqliteDialect } = require('kysely-bun-worker/normal')",
+      '',
+      ';(async () => {',
+      "  const db = new Kysely({ dialect: new BunSqliteDialect({ url: ':memory:' }) })",
+      '  try {',
+      '    const { rows } = await sql`select 1 as value`.execute(db)',
+      "    if (rows.length !== 1 || rows[0].value !== 1) throw new Error('Unexpected query result')",
+      '  } finally {',
+      '    await db.destroy()',
+      '  }',
+      '})().catch((error) => {',
+      '  console.error(error)',
+      '  process.exitCode = 1',
+      '})',
+    ].join('\n'),
+  )
+  symlinkSync(packageRoot, join(nodeModulesDir, 'kysely-bun-worker'), 'dir')
+  symlinkSync(resolve(packageRoot, 'node_modules/kysely'), join(nodeModulesDir, 'kysely'), 'dir')
+}

--- a/packages/dialect-bun-worker/test/package.test.ts
+++ b/packages/dialect-bun-worker/test/package.test.ts
@@ -18,7 +18,9 @@ describe('bun sqlite package', () => {
         stdout: 'pipe',
       })
 
-      const output = new TextDecoder().decode(result.stderr)
+      const stdout = new TextDecoder().decode(result.stdout)
+      const stderr = new TextDecoder().decode(result.stderr)
+      const output = [stdout, stderr].filter(Boolean).join('\n')
       expect(result.exitCode, output).toBe(0)
     } finally {
       rmSync(projectDir, { force: true, recursive: true })

--- a/packages/dialect-bun-worker/test/package.test.ts
+++ b/packages/dialect-bun-worker/test/package.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+import { createRequire } from 'node:module'
+
+import { Kysely, sql } from 'kysely'
+
+const require = createRequire(import.meta.url)
+
+describe('bun sqlite package', () => {
+  it('executes a query through the CommonJS normal entry point', async () => {
+    const { BunSqliteDialect } = require('../dist/normal.cjs')
+    const db = new Kysely({ dialect: new BunSqliteDialect({ url: ':memory:' }) })
+
+    try {
+      const result = await sql<{ value: number }>`select 1 as value`.execute(db)
+      expect(result.rows).toEqual([{ value: 1 }])
+    } finally {
+      await db.destroy()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #41 by importing `Database` from `bun:sqlite` as a named export, so the CommonJS normal entry constructs the database constructor instead of the module namespace.

Adds a regression test that builds the package, loads `dist/normal.cjs` through `require`, and executes a query against an in-memory database.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm format:check`