### PR TITLE
Fix Bun worker retry and duplicate imports

### DIFF
--- a/packages/dialect-bun-worker/README.md
+++ b/packages/dialect-bun-worker/README.md
@@ -35,6 +35,16 @@ createOnMessageCallback((fileName, options) => {
 })
 ```
 
+When passing a custom worker, prefer a factory if initialization may be retried:
+
+```ts
+const dialect = new BunWorkerDialect({
+  worker: () => new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' }),
+})
+```
+
+A worker instance is still supported, but it cannot be recreated after the driver terminates it during failed initialization.
+
 ### Normal Dialect
 
 Use `BunSqliteDialect` to run SQL on the main thread.
@@ -65,9 +75,13 @@ export type BunWorkerDialectConfig = {
    */
   cacheStatement?: boolean
   /**
-   * custom worker, default is a worker that use bun:sqlite
+   * Custom worker instance or factory.
+   *
+   * A worker instance cannot be recreated after a failed initialization because
+   * the driver terminates failed workers. Use a factory when retryable custom
+   * worker initialization is required.
    */
-  worker?: Worker
+  worker?: Worker | (() => Worker)
   /**
    * DB constructor options
    * @default { create: true }

--- a/packages/dialect-bun-worker/src/executor.ts
+++ b/packages/dialect-bun-worker/src/executor.ts
@@ -1,5 +1,4 @@
-import type { Statement } from 'bun:sqlite'
-import type { Database } from 'bun:sqlite'
+import type { Database, Statement } from 'bun:sqlite'
 
 import type { IGenericSqlite } from 'kysely-generic-sqlite'
 import { parseBigInt } from 'kysely-generic-sqlite'

--- a/packages/dialect-bun-worker/src/index.ts
+++ b/packages/dialect-bun-worker/src/index.ts
@@ -20,14 +20,14 @@ export class BunWorkerDialect extends GenericSqliteWorkerDialect<globalThis.Work
       worker,
       dbOptions: opt = { create: true },
     } = config || {}
-    if (!worker) {
-      worker = new Worker(new URL('./worker', import.meta.url), { type: 'module' })
-    }
     super(
       () => ({
         data: { cache: cacheStatement, fileName, opt },
         handle: handleWebWorker,
-        worker,
+        worker:
+          typeof worker === 'function'
+            ? worker()
+            : (worker ?? new Worker(new URL('./worker', import.meta.url), { type: 'module' })),
       }),
       onCreateConnection,
     )

--- a/packages/dialect-bun-worker/src/type.ts
+++ b/packages/dialect-bun-worker/src/type.ts
@@ -7,6 +7,8 @@ export type DBOptions = Exclude<ConstructorParameters<typeof Database>[1], undef
 /**
  * Configuration for {@link BunWorkerDialect}.
  */
+export type BunWorkerFactory = () => Worker
+
 export interface BunWorkerDialectConfig extends IBaseSqliteDialectConfig {
   /**
    * DB file path
@@ -25,9 +27,13 @@ export interface BunWorkerDialectConfig extends IBaseSqliteDialectConfig {
    */
   cacheStatement?: boolean
   /**
-   * custom worker, default is a worker that use bun:sqlite
+   * Custom worker instance or factory.
+   *
+   * A worker instance cannot be recreated after a failed initialization because
+   * the driver terminates failed workers. Use a factory when retryable custom
+   * worker initialization is required.
    */
-  worker?: Worker
+  worker?: Worker | BunWorkerFactory
 }
 
 /**

--- a/packages/dialect-bun-worker/test/index.test.ts
+++ b/packages/dialect-bun-worker/test/index.test.ts
@@ -1,10 +1,42 @@
 import { describe, expect, it } from 'bun:test'
 
+import { Kysely, sql } from 'kysely'
+
 import { testCase } from '../../test-utils'
 import { BunWorkerDialect } from '../src'
 
 describe('bun worker dialect test', () => {
   it('bun:sqlite worker', async () => {
     await testCase(new BunWorkerDialect() as never, expect)
+  })
+
+  it('recreates the default worker after failed initialization', async () => {
+    let attempts = 0
+    const db = new Kysely<never>({
+      dialect: new BunWorkerDialect({
+        onCreateConnection: async () => {
+          attempts += 1
+          if (attempts === 1) {
+            throw new Error('setup failed')
+          }
+        },
+      }) as never,
+    })
+
+    try {
+      await expect(sql`select 1`.execute(db)).rejects.toThrow('setup failed')
+
+      const result = await Promise.race([
+        sql<{ value: number }>`select 1 as value`.execute(db),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('second query timed out')), 1_000),
+        ),
+      ])
+
+      expect(result.rows).toStrictEqual([{ value: 1 }])
+      expect(attempts).toBe(2)
+    } finally {
+      await db.destroy()
+    }
   })
 })

--- a/todo.md
+++ b/todo.md
@@ -8,9 +8,9 @@ All seven reported issues are reproducible. Item 6 is an adapter API gap rather 
 
 | Status | Priority | Issue                                                              | Effort | Fix risk | Confidence |
 | ------ | -------- | ------------------------------------------------------------------ | ------ | -------- | ---------- |
-| TODO   | P0       | Merge duplicate Bun SQLite type imports                            | S      | Low      | High       |
+| DONE   | P0       | Merge duplicate Bun SQLite type imports                            | S      | Low      | High       |
 | TODO   | P1       | Preserve `Buffer` database sources across the Node worker boundary | S      | Low      | High       |
-| TODO   | P1       | Recreate the default Bun worker after failed initialization        | S      | Medium   | High       |
+| DONE   | P1       | Recreate the default Bun worker after failed initialization        | S      | Medium   | High       |
 | TODO   | P1       | Apply the documented `preferOPFS: true` default                    | S      | Low      | High       |
 | TODO   | P1       | Remove the invalid built-in classic-worker fallback                | S      | Medium   | High       |
 | TODO   | P2       | Expose raw-query classification in Tauri, NodeWasm, and CrSqlite   | M      | Medium   | High       |
@@ -25,9 +25,9 @@ All seven reported issues are reproducible. Item 6 is an adapter API gap rather 
 
 ## 1. Merge duplicate Bun SQLite type imports
 
-- [ ] Replace the two `bun:sqlite` type-only imports in `packages/dialect-bun-worker/src/executor.ts:1-2` with one import containing both `Database` and `Statement`.
-- [ ] Do not change runtime imports or executor behavior.
-- [ ] Run `pnpm lint:check`; it must exit 0 with no `import(no-duplicates)` diagnostic.
+- [x] Replace the two `bun:sqlite` type-only imports in `packages/dialect-bun-worker/src/executor.ts:1-2` with one import containing both `Database` and `Statement`.
+- [x] Do not change runtime imports or executor behavior.
+- [x] Run `pnpm lint:check`; it must exit 0 with no `import(no-duplicates)` diagnostic.
 
 Observed failure:
 
@@ -68,11 +68,11 @@ FIRST_ERROR setup failed
 SECOND_TIMEOUT ATTEMPTS 1
 ```
 
-- [ ] Move default worker construction into the executor passed to `super`, so every initialization attempt owns a fresh default worker.
-- [ ] Preserve one worker per successful driver lifetime; do not create a worker per query.
-- [ ] Decide the custom-worker retry contract explicitly. The preferred backward-compatible API is to continue accepting a `Worker` instance and additionally accept a worker factory for callers that need retryable custom workers. Document that an instance cannot be recreated after termination.
-- [ ] Add a Bun regression test where `onCreateConnection` fails once, the first query rejects with that error, and a second query on the same `Kysely` instance succeeds within a bounded timeout.
-- [ ] Assert the callback runs twice and destroy the database in `finally`.
+- [x] Move default worker construction into the executor passed to `super`, so every initialization attempt owns a fresh default worker.
+- [x] Preserve one worker per successful driver lifetime; do not create a worker per query.
+- [x] Decide the custom-worker retry contract explicitly. The preferred backward-compatible API is to continue accepting a `Worker` instance and additionally accept a worker factory for callers that need retryable custom workers. Document that an instance cannot be recreated after termination.
+- [x] Add a Bun regression test where `onCreateConnection` fails once, the first query rejects with that error, and a second query on the same `Kysely` instance succeeds within a bounded timeout.
+- [x] Assert the callback runs twice and destroy the database in `finally`.
 
 Verification:
 


### PR DESCRIPTION
### Motivation

- Fix a lint failure caused by duplicate `bun:sqlite` type imports and eliminate the corresponding diagnostic. 
- Resolve a retry bug where the default Bun worker was created once in the constructor and reused after termination, causing initialization retries to hang. 
- Provide a backward-compatible API for custom workers that supports retryable worker creation via a factory and document the contract.

### Description

- Replace two separate `bun:sqlite` type-only imports with a single `import type { Database, Statement } from 'bun:sqlite'` in `packages/dialect-bun-worker/src/executor.ts`. 
- Move default worker construction into the executor factory passed to `super(...)` so each init attempt gets a fresh worker and successful driver lifetimes still reuse one worker, implemented in `packages/dialect-bun-worker/src/index.ts`. 
- Add `BunWorkerFactory` and expand the `worker` config to `Worker | BunWorkerFactory` in `packages/dialect-bun-worker/src/type.ts`, and document factory usage and retry semantics in `packages/dialect-bun-worker/README.md`. 
- Add a Bun regression test `packages/dialect-bun-worker/test/index.test.ts` that forces `onCreateConnection` to fail once, verifies the first query fails, and asserts a subsequent query succeeds and that initialization was retried. 
- Mark the related items complete in `todo.md` and apply formatting fixes to the README.

### Testing

- Ran `pnpm format:check` and formatting checks passed. 
- Ran `pnpm lint:check` and no `import(no-duplicates)` diagnostic remained. 
- Ran the workspace build with `pnpm build` and TypeScript checks with `pnpm typecheck`, both succeeded. 
- Ran the Bun package tests with `pnpm --filter kysely-bun-worker test` (which runs `bun test`) and all Bun tests for the package passed. 
- Verified `git diff --check` passed with no whitespace or patch errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eb99789f48330bc00b02caba90d9e)