### PR TITLE
Normalize and preserve Buffer database sources in sqlite worker

### DIFF
--- a/packages/dialect-sqlite-worker/src/worker/utils.ts
+++ b/packages/dialect-sqlite-worker/src/worker/utils.ts
@@ -19,7 +19,16 @@ export type CreateDatabaseFn = (
  * Default database factory — creates a new `better-sqlite3` Database instance.
  */
 export const defaultCreateDatabaseFn: CreateDatabaseFn = (fileName, options) =>
-  new Database(fileName, options)
+  new Database(normalizeDatabaseSource(fileName), options)
+
+function normalizeDatabaseSource(
+  source?: string | Buffer | Uint8Array,
+): string | Buffer | undefined {
+  if (typeof source === 'string' || source === undefined || Buffer.isBuffer(source)) {
+    return source
+  }
+  return Buffer.from(source)
+}
 
 /**
  * Handle worker messages, with optional custom message handler.

--- a/packages/dialect-sqlite-worker/src/worker/utils.ts
+++ b/packages/dialect-sqlite-worker/src/worker/utils.ts
@@ -61,7 +61,7 @@ export function createOnMessageCallback(
 ): void {
   const { src, option } = workerData
   createNodeOnMessageCallback<{}, BetterSqlite3.Database>(async () => {
-    const db = await create(src, option)
+    const db = await create(normalizeDatabaseSource(src), option)
     return createSqliteExecutor(db)
   }, custom)
 }

--- a/packages/dialect-sqlite-worker/test/index.test.ts
+++ b/packages/dialect-sqlite-worker/test/index.test.ts
@@ -1,7 +1,16 @@
+import Database from 'better-sqlite3'
+import { Kysely } from 'kysely'
 import { describe, expect, it } from 'vitest'
 
 import { testCase } from '../../test-utils'
 import { SqliteWorkerDialect } from '../dist/index.mjs'
+
+interface SeededDb {
+  seed: {
+    id: number
+    name: string
+  }
+}
 
 describe('sqlite worker dialect test', () => {
   it('constructs with the default ESM worker path', async () => {
@@ -12,6 +21,30 @@ describe('sqlite worker dialect test', () => {
     const driver = dialect.createDriver()
     await expect(driver.init()).resolves.toBeUndefined()
     await driver.destroy()
+  })
+
+  it('preserves Buffer database sources in the default ESM worker', async () => {
+    const source = new Database(':memory:')
+    source.exec(`
+      create table seed (id integer primary key, name text not null);
+      insert into seed (id, name) values (1, 'from serialized buffer');
+    `)
+    const serialized = source.serialize()
+    source.close()
+
+    const db = new Kysely<SeededDb>({
+      dialect: new SqliteWorkerDialect({
+        source: serialized,
+      }),
+    })
+
+    try {
+      await expect(db.selectFrom('seed').selectAll().execute()).resolves.toStrictEqual([
+        { id: 1, name: 'from serialized buffer' },
+      ])
+    } finally {
+      await db.destroy()
+    }
   })
 
   it('better-sqlite3 worker', async () => {

--- a/packages/dialect-sqlite-worker/test/index.test.ts
+++ b/packages/dialect-sqlite-worker/test/index.test.ts
@@ -1,9 +1,18 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
 import Database from 'better-sqlite3'
 import { Kysely } from 'kysely'
 import { describe, expect, it } from 'vitest'
 
 import { testCase } from '../../test-utils'
 import { SqliteWorkerDialect } from '../dist/index.mjs'
+
+const distIndexUrl = pathToFileURL(
+  join(dirname(fileURLToPath(import.meta.url)), '../dist/index.mjs'),
+).href
 
 interface SeededDb {
   seed: {
@@ -44,6 +53,49 @@ describe('sqlite worker dialect test', () => {
       ])
     } finally {
       await db.destroy()
+    }
+  })
+
+  it('passes Buffer database sources to custom worker create callbacks', async () => {
+    const source = new Database(':memory:')
+    source.exec(`
+      create table seed (id integer primary key, name text not null);
+      insert into seed (id, name) values (1, 'from custom worker');
+    `)
+    const serialized = source.serialize()
+    source.close()
+
+    const tempDir = await mkdtemp(join(tmpdir(), 'kysely-sqlite-worker-'))
+    const workerPath = join(tempDir, 'custom-worker.mjs')
+
+    await writeFile(
+      workerPath,
+      `
+        import { createOnMessageCallback, defaultCreateDatabaseFn } from ${JSON.stringify(distIndexUrl)}
+
+        createOnMessageCallback((source, options) => {
+          if (!Buffer.isBuffer(source)) {
+            throw new Error('expected Buffer source')
+          }
+          return defaultCreateDatabaseFn(source, options)
+        })
+      `,
+    )
+
+    const db = new Kysely<SeededDb>({
+      dialect: new SqliteWorkerDialect({
+        source: serialized,
+        workerPath,
+      }),
+    })
+
+    try {
+      await expect(db.selectFrom('seed').selectAll().execute()).resolves.toStrictEqual([
+        { id: 1, name: 'from custom worker' },
+      ])
+    } finally {
+      await db.destroy()
+      await rm(tempDir, { recursive: true })
     }
   })
 


### PR DESCRIPTION
### Motivation
- Worker structured-clone converts `Buffer` to `Uint8Array`, which causes `better-sqlite3` to reject the argument when constructing a database; the worker should accept the same public `source` contract and reconstruct `Buffer` where appropriate. 

### Description
- Added `normalizeDatabaseSource(source?: string | Buffer | Uint8Array)` in `packages/dialect-sqlite-worker/src/worker/utils.ts` and use it from the default factory so `Uint8Array` values are converted back to `Buffer` while leaving strings and existing `Buffer`s unchanged.  
- Updated `defaultCreateDatabaseFn` to call `normalizeDatabaseSource` before constructing `better-sqlite3` `Database`.  
- Added a regression test in `packages/dialect-sqlite-worker/test/index.test.ts` that seeds an in-memory `better-sqlite3` DB, serializes it to a `Buffer`, passes that `Buffer` through the default ESM worker path, and asserts the seeded row is queryable.  
- Applied formatting to the modified files.

### Testing
- Built dependent packages with `pnpm --filter kysely-generic-sqlite build` and `pnpm --filter kysely-sqlite-worker build`, and both builds completed successfully.  
- Ran the sqlite-worker tests with `pnpm exec vitest run packages/dialect-sqlite-worker/test/index.test.ts` and the added regression test passed.  
- Ran the workspace typecheck with `pnpm typecheck` which passed.  
- Ran `pnpm format:check` which passed; `git diff --check` passed as well.  
- `pnpm lint:check` still reports a pre-existing unrelated failure for a duplicate `bun:sqlite` type import in `packages/dialect-bun-worker/src/executor.ts` (this corresponds to a separate TODO and is intentionally out of scope for this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ec0d843c883309b0745d5a2351de5)