### PR TITLE
Wa-sqlite worker: default `preferOPFS = true` and remove classic-worker fallback

### DIFF
--- a/packages/dialect-wasqlite-worker/README.md
+++ b/packages/dialect-wasqlite-worker/README.md
@@ -64,9 +64,9 @@ export interface WaSqliteWorkerDialectConfig {
   /**
    * wasqlite worker
    *
-   * The built-in worker uses the packaged worker entry.
-   * It prefers module workers when the runtime supports them.
-   * You can still provide a custom worker if you need explicit worker options.
+   * The built-in worker uses the packaged ESM worker entry and requires module worker support.
+   * Provide a custom worker factory that returns a classic-compatible bundled worker
+   * when supporting browsers without module workers.
    * @param supportModuleWorker if support { type: 'module' } in worker options
    * @example
    * (support) => support

--- a/packages/dialect-wasqlite-worker/src/index.ts
+++ b/packages/dialect-wasqlite-worker/src/index.ts
@@ -19,7 +19,7 @@ export class WaSqliteWorkerDialect extends GenericSqliteWorkerDialect<globalThis
    * @param config - {@link WaSqliteWorkerDialectConfig}
    */
   constructor(config: WaSqliteWorkerDialectConfig) {
-    const { onCreateConnection, worker, fileName, preferOPFS, url } = config
+    const { onCreateConnection, worker, fileName, preferOPFS = true, url } = config
     super(async () => {
       const supportModule = isModuleWorkerSupport()
       const useOPFS = preferOPFS ? await isOpfsSupported() : false
@@ -33,11 +33,19 @@ export class WaSqliteWorkerDialect extends GenericSqliteWorkerDialect<globalThis
           ? worker instanceof globalThis.Worker
             ? worker
             : worker(supportModule)
-          : supportModule
-            ? new Worker(new URL('worker.js', import.meta.url), { type: 'module' })
-            : new Worker(new URL('worker.js', import.meta.url)),
+          : createBuiltInWorker(supportModule),
         handle: handleWebWorker,
       }
     }, onCreateConnection)
   }
+}
+
+function createBuiltInWorker(supportModuleWorker: boolean): Worker {
+  if (!supportModuleWorker) {
+    throw new Error(
+      'WaSqliteWorkerDialect requires module worker support for the built-in worker. Provide config.worker with a classic-compatible bundled worker for this browser.',
+    )
+  }
+
+  return new Worker(new URL('worker.js', import.meta.url), { type: 'module' })
 }

--- a/packages/dialect-wasqlite-worker/src/type.ts
+++ b/packages/dialect-wasqlite-worker/src/type.ts
@@ -13,9 +13,9 @@ export interface WaSqliteWorkerDialectConfig extends IBaseSqliteDialectConfig {
   /**
    * Custom SQLite worker
    *
-   * The built-in worker uses the packaged worker entry.
-   * It prefers module workers when the runtime supports them.
-   * You can still provide a custom worker if you need explicit worker options.
+   * The built-in worker uses the packaged ESM worker entry and requires module worker support.
+   * Provide a custom worker factory that returns a classic-compatible bundled worker
+   * when supporting browsers without module workers.
    * @param supportModuleWorker whether the runtime supports `{ type: 'module' }` workers
    * @example
    * (supportModuleWorker) => supportModuleWorker

--- a/packages/dialect-wasqlite-worker/test/index.test.ts
+++ b/packages/dialect-wasqlite-worker/test/index.test.ts
@@ -1,9 +1,20 @@
 import { Worker as NodeWorker } from 'node:worker_threads'
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { testCase } from '../../test-utils'
 import { WaSqliteWorkerDialect } from '../src'
+
+const { isModuleWorkerSupportMock, isOpfsSupportedMock } = vi.hoisted(() => ({
+  isModuleWorkerSupportMock: vi.fn<() => boolean>(),
+  isOpfsSupportedMock: vi.fn<() => boolean | Promise<boolean>>(),
+}))
+
+vi.mock('@subframe7536/sqlite-wasm', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@subframe7536/sqlite-wasm')>()),
+  isModuleWorkerSupport: isModuleWorkerSupportMock,
+  isOpfsSupported: isOpfsSupportedMock,
+}))
 
 class WebWorkerMock {
   onmessage: ((event: MessageEvent) => void) | null = null
@@ -23,9 +34,50 @@ class WebWorkerMock {
   }
 }
 
+class RecordingWorkerMock {
+  static instances: RecordingWorkerMock[] = []
+
+  onmessage: ((event: MessageEvent) => void) | null = null
+  readonly options: WorkerOptions | undefined
+  readonly url: string | URL
+  readonly messages: unknown[] = []
+  terminated = false
+
+  constructor(url: string | URL, options?: WorkerOptions) {
+    this.url = url
+    this.options = options
+    RecordingWorkerMock.instances.push(this)
+  }
+
+  postMessage(data: unknown): void {
+    this.messages.push(data)
+    const request = data as { id?: string | number; type?: string }
+    if (request.type === 'init' || request.type === 'close') {
+      queueMicrotask(() =>
+        this.onmessage?.({
+          data: { id: request.id, type: request.type === 'init' ? 'ready' : 'closed' },
+        } as MessageEvent),
+      )
+    }
+  }
+
+  terminate(): void {
+    this.terminated = true
+  }
+}
+
 globalThis.Worker = WebWorkerMock as never
 
 describe('wasqlite worker dialect test', () => {
+  beforeEach(() => {
+    globalThis.Worker = WebWorkerMock as never
+    isModuleWorkerSupportMock.mockClear()
+    isOpfsSupportedMock.mockClear()
+    isModuleWorkerSupportMock.mockReturnValue(true)
+    isOpfsSupportedMock.mockResolvedValue(false)
+    RecordingWorkerMock.instances = []
+  })
+
   it('mock web worker', async () => {
     const dialect = new WaSqliteWorkerDialect({
       fileName: ':memory:',
@@ -34,5 +86,94 @@ describe('wasqlite worker dialect test', () => {
     })
 
     await testCase(dialect, expect, true)
+  })
+
+  it('uses OPFS by default when supported', async () => {
+    globalThis.Worker = RecordingWorkerMock as never
+    isOpfsSupportedMock.mockResolvedValue(true)
+    const url = vi.fn((useAsyncWasm: boolean) => `wasm-${String(useAsyncWasm)}`)
+
+    const dialect = new WaSqliteWorkerDialect({
+      fileName: 'opfs.db',
+      url,
+    })
+
+    const driver = dialect.createDriver()
+    await driver.init()
+
+    expect(isOpfsSupportedMock).toHaveBeenCalledOnce()
+    expect(url).toHaveBeenCalledWith(false)
+    expect(RecordingWorkerMock.instances).toHaveLength(1)
+    expect(RecordingWorkerMock.instances[0]?.options).toEqual({ type: 'module' })
+    expect(RecordingWorkerMock.instances[0]?.messages).toEqual([
+      {
+        id: 'generic-sqlite-1',
+        type: 'init',
+        data: { fileName: 'opfs.db', useOPFS: true, url: 'wasm-false' },
+      },
+    ])
+    await driver.destroy()
+  })
+
+  it('uses IndexedDB without OPFS detection when preferOPFS is false', async () => {
+    globalThis.Worker = RecordingWorkerMock as never
+    const url = vi.fn((useAsyncWasm: boolean) => `wasm-${String(useAsyncWasm)}`)
+
+    const dialect = new WaSqliteWorkerDialect({
+      fileName: 'idb.db',
+      preferOPFS: false,
+      url,
+    })
+
+    const driver = dialect.createDriver()
+    await driver.init()
+
+    expect(isOpfsSupportedMock).not.toHaveBeenCalled()
+    expect(url).toHaveBeenCalledWith(true)
+    expect(RecordingWorkerMock.instances[0]?.messages).toEqual([
+      {
+        id: 'generic-sqlite-1',
+        type: 'init',
+        data: { fileName: 'idb.db', useOPFS: false, url: 'wasm-true' },
+      },
+    ])
+    await driver.destroy()
+  })
+
+  it('throws an actionable error without module worker support or a custom worker', async () => {
+    globalThis.Worker = RecordingWorkerMock as never
+    isModuleWorkerSupportMock.mockReturnValue(false)
+
+    const dialect = new WaSqliteWorkerDialect({
+      fileName: 'legacy.db',
+      preferOPFS: false,
+    })
+
+    await expect(dialect.createDriver().init()).rejects.toThrow(
+      'WaSqliteWorkerDialect requires module worker support for the built-in worker. Provide config.worker with a classic-compatible bundled worker for this browser.',
+    )
+    expect(RecordingWorkerMock.instances).toHaveLength(0)
+  })
+
+  it('passes module support to a custom worker factory', async () => {
+    globalThis.Worker = RecordingWorkerMock as never
+    isModuleWorkerSupportMock.mockReturnValue(false)
+    const workerFactory = vi.fn(
+      (_supportModuleWorker: boolean) => new RecordingWorkerMock('classic-worker.js'),
+    )
+
+    const dialect = new WaSqliteWorkerDialect({
+      fileName: 'custom.db',
+      preferOPFS: false,
+      worker: workerFactory as never,
+    })
+
+    const driver = dialect.createDriver()
+    await driver.init()
+
+    expect(workerFactory).toHaveBeenCalledWith(false)
+    expect(RecordingWorkerMock.instances).toHaveLength(1)
+    expect(RecordingWorkerMock.instances[0]?.url).toBe('classic-worker.js')
+    await driver.destroy()
   })
 })

--- a/todo.md
+++ b/todo.md
@@ -11,8 +11,8 @@ All seven reported issues are reproducible. Item 6 is an adapter API gap rather 
 | TODO   | P0       | Merge duplicate Bun SQLite type imports                            | S      | Low      | High       |
 | TODO   | P1       | Preserve `Buffer` database sources across the Node worker boundary | S      | Low      | High       |
 | TODO   | P1       | Recreate the default Bun worker after failed initialization        | S      | Medium   | High       |
-| TODO   | P1       | Apply the documented `preferOPFS: true` default                    | S      | Low      | High       |
-| TODO   | P1       | Remove the invalid built-in classic-worker fallback                | S      | Medium   | High       |
+| DONE   | P1       | Apply the documented `preferOPFS: true` default                    | S      | Low      | High       |
+| DONE   | P1       | Remove the invalid built-in classic-worker fallback                | S      | Medium   | High       |
 | TODO   | P2       | Expose raw-query classification in Tauri, NodeWasm, and CrSqlite   | M      | Medium   | High       |
 | TODO   | P2       | Await direct Promise database values in the Tauri dialect          | S      | Low      | High       |
 
@@ -95,10 +95,10 @@ preferOPFS omitted -> useOPFS false
 preferOPFS true    -> useOPFS true
 ```
 
-- [ ] Default `preferOPFS` to `true` during configuration destructuring.
-- [ ] Preserve explicit `preferOPFS: false` as the opt-out that skips OPFS detection and uses IndexedDB.
-- [ ] Add tests that mock `isOpfsSupported`: omitted preference with support returns `useOPFS: true`; explicit false returns `useOPFS: false` and does not require OPFS support.
-- [ ] Assert the `url` callback still receives `useAsyncWasm = !useOPFS` for both branches.
+- [x] Default `preferOPFS` to `true` during configuration destructuring.
+- [x] Preserve explicit `preferOPFS: false` as the opt-out that skips OPFS detection and uses IndexedDB.
+- [x] Add tests that mock `isOpfsSupported`: omitted preference with support returns `useOPFS: true`; explicit false returns `useOPFS: false` and does not require OPFS support.
+- [x] Assert the `url` callback still receives `useAsyncWasm = !useOPFS` for both branches.
 
 Verification:
 
@@ -120,11 +120,11 @@ Verified classic-script parse result:
 SyntaxError: Cannot use import statement outside a module
 ```
 
-- [ ] Keep the built-in worker on the module-worker path only.
-- [ ] When module workers are unsupported and no custom worker is provided, throw an actionable error that tells the caller to provide `config.worker` with a classic-compatible bundled worker.
-- [ ] Preserve the custom worker factory call with `supportModuleWorker === false`; this remains the supported legacy-browser escape hatch.
-- [ ] Add tests for: built-in module worker construction, explicit failure without module support, and a custom factory receiving false and supplying a usable worker.
-- [ ] Update the wa-sqlite README/JSDoc so it never implies that the packaged ESM worker can run as a classic script.
+- [x] Keep the built-in worker on the module-worker path only.
+- [x] When module workers are unsupported and no custom worker is provided, throw an actionable error that tells the caller to provide `config.worker` with a classic-compatible bundled worker.
+- [x] Preserve the custom worker factory call with `supportModuleWorker === false`; this remains the supported legacy-browser escape hatch.
+- [x] Add tests for: built-in module worker construction, explicit failure without module support, and a custom factory receiving false and supplying a usable worker.
+- [x] Update the wa-sqlite README/JSDoc so it never implies that the packaged ESM worker can run as a classic script.
 
 Verification:
 


### PR DESCRIPTION
### Motivation
- Align runtime behavior with documented defaults by making `preferOPFS` default to `true` so omitted configs prefer OPFS when available.
- Avoid attempting to run the packaged ESM `worker.js` as a classic script in runtimes without module-worker support and provide an actionable error instead.
- Make the dialect behavior explicit and testable for the OPFS/IndexedDB selection and legacy custom-worker factory paths.

### Description
- Defaulted `preferOPFS` to `true` in `packages/dialect-wasqlite-worker/src/index.ts` by changing the config destructuring to `preferOPFS = true` and preserved the explicit opt-out behavior.
- Replaced the old dual-path builtin-worker logic with a single `createBuiltInWorker` helper that throws when `supportModuleWorker === false` and otherwise constructs a module `Worker` with `{ type: 'module' }` in `packages/dialect-wasqlite-worker/src/index.ts`.
- Updated JSDoc and `README` text in `packages/dialect-wasqlite-worker/src/type.ts` and `packages/dialect-wasqlite-worker/README.md` to state the built-in worker is ESM/module-worker only and to document providing a custom factory for classic-worker compatibility.
- Added regression tests in `packages/dialect-wasqlite-worker/test/index.test.ts` (mocks for `isOpfsSupported` and module-worker support) that verify the default OPFS behavior, the explicit `preferOPFS: false` opt-out, the actionable error when module workers are unsupported, and that a custom worker factory receives the module-support hint; updated worker mock code to respond with `ready`/`closed` appropriately.
- Marked items 4 and 5 complete in `todo.md` to reflect these fixes.

### Testing
- Ran `pnpm exec vitest run packages/dialect-wasqlite-worker/test/index.test.ts` and the package test suite passed (all tests green).
- Built the package with `pnpm --filter kysely-wasqlite-worker build` and verified the emitted `dist/worker.js` remains ESM by running a `node` VM script that expects a parse-time `import` (the check passed).
- Ran the full workspace build and typecheck with `pnpm build` and `pnpm typecheck` and both completed successfully.
- Ran `pnpm format:check` and `git diff --check` which passed; `pnpm lint:check` still reports a pre-existing `import(no-duplicates)` error in `packages/dialect-bun-worker/src/executor.ts` (tracked as TODO item 1 and fixed in a separate PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ec178d6bc83309d769836604903d7)